### PR TITLE
test: unit test coverage for all 6 services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-usage-monitor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-usage-monitor",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "auto-launch": "^5.0.6",
         "chart.js": "^4.4.0",
@@ -15,10 +15,72 @@
       "devDependencies": {
         "@types/auto-launch": "^5.0.5",
         "@types/node": "^20.0.0",
+        "@vitest/coverage-v8": "^4.1.2",
         "electron": "^28.0.0",
         "electron-builder": "^24.0.0",
         "esbuild": "^0.19.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.2"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -312,6 +374,40 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
@@ -601,6 +697,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
@@ -618,6 +732,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
@@ -633,6 +765,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -806,6 +956,34 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -890,6 +1068,33 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -900,6 +1105,268 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -913,6 +1380,13 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -937,6 +1411,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/auto-launch": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@types/auto-launch/-/auto-launch-5.0.5.tgz",
@@ -957,6 +1442,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -966,6 +1462,20 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -1050,6 +1560,123 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -1377,6 +2004,28 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -1699,6 +2348,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2001,6 +2660,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2181,6 +2847,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -2655,6 +3331,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2755,6 +3438,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -2824,6 +3527,24 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/filelist": {
@@ -2937,6 +3658,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3235,6 +3971,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -3416,6 +4159,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -3449,6 +4231,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -3581,6 +4370,267 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -3659,6 +4709,57 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -3821,6 +4922,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -3863,6 +4983,17 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -4003,6 +5134,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -4016,6 +5154,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-up": {
       "version": "3.1.0",
@@ -4042,6 +5193,35 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/process-nextick-args": {
@@ -4223,6 +5403,40 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4344,6 +5558,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4421,6 +5642,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -4440,6 +5671,13 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -4449,6 +5687,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4644,6 +5889,50 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -4673,6 +5962,14 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -4767,6 +6064,651 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4781,6 +6723,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winreg": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "tsc -p tsconfig.main.json && electron dist/main.js",
     "build": "tsc -p tsconfig.main.json && node build-renderer.js",
     "dist": "npm run build && electron-builder --win",
-    "dist:portable": "npm run build && electron-builder --win portable"
+    "dist:portable": "npm run build && electron-builder --win portable",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "auto-launch": "^5.0.6",
@@ -17,10 +20,12 @@
   "devDependencies": {
     "@types/auto-launch": "^5.0.5",
     "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^4.1.2",
     "electron": "^28.0.0",
     "electron-builder": "^24.0.0",
     "esbuild": "^0.19.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.2"
   },
   "build": {
     "appId": "com.claudeusage.monitor",
@@ -33,11 +38,15 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "portable",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "icon": "assets/icon.ico"

--- a/src/services/__tests__/credentialService.test.ts
+++ b/src/services/__tests__/credentialService.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('fs')
+vi.mock('https')
+
+import * as fs from 'fs'
+import * as https from 'https'
+import { CredentialsFile } from '../../models/usageData'
+
+// Dynamically import after mocks so the module picks up the mocked fs/https
+// We re-import in each test group via a local helper to avoid stale module state.
+// credentialService has no module-level mutable state that depends on fs/https at
+// import time, so a single static import is fine here.
+import { getAccessToken } from '../credentialService'
+
+// ---- helpers ----------------------------------------------------------------
+
+const WIN_PATH_SUFFIX = '.claude\\.credentials.json'
+
+function buildCreds(overrides: Partial<CredentialsFile['claudeAiOauth']> = {}): CredentialsFile {
+  return {
+    claudeAiOauth: {
+      accessToken: 'valid-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000, // 1 hour from now
+      ...overrides,
+    },
+  }
+}
+
+/**
+ * Set up fs mocks so that:
+ * - The Windows credential path exists
+ * - The WSL base path does NOT exist (keeps things simple)
+ * - statSync returns the supplied mtimeMs
+ * - readFileSync returns the supplied credentials JSON
+ */
+function mockSingleCredFile(
+  creds: CredentialsFile,
+  mtimeMs: number = Date.now()
+): void {
+  vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+    const str = String(p)
+    // WSL base – does not exist
+    if (str === '\\\\wsl.localhost') return false
+    // Windows credentials path
+    if (str.endsWith(WIN_PATH_SUFFIX) || str.includes('.credentials.json')) return true
+    return false
+  })
+  vi.mocked(fs.statSync).mockReturnValue({ mtimeMs } as ReturnType<typeof fs.statSync>)
+  vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(creds))
+}
+
+/**
+ * Simulate a successful https refresh response.
+ */
+function mockHttpsRefreshResponse(responseBody: object): void {
+  const req = {
+    on: vi.fn(),
+    end: vi.fn(),
+    setTimeout: vi.fn(),
+    destroy: vi.fn(),
+    write: vi.fn(),
+  }
+  const res = { on: vi.fn() }
+  vi.mocked(res.on).mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+    if (event === 'data') cb(JSON.stringify(responseBody))
+    if (event === 'end') cb()
+    return res
+  })
+  vi.mocked(https.request).mockImplementation((_opts: unknown, cb: unknown) => {
+    ;(cb as (r: typeof res) => void)(res)
+    return req as unknown as ReturnType<typeof https.request>
+  })
+}
+
+/**
+ * Simulate an https request that emits an error.
+ */
+function mockHttpsError(err: Error): void {
+  const req = {
+    on: vi.fn((event: string, cb: (e: Error) => void) => {
+      if (event === 'error') cb(err)
+      return req
+    }),
+    end: vi.fn(),
+    setTimeout: vi.fn(),
+    destroy: vi.fn(),
+    write: vi.fn(),
+  }
+  vi.mocked(https.request).mockImplementation(() => req as unknown as ReturnType<typeof https.request>)
+}
+
+// ---- tests ------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  // Provide a sensible USERPROFILE so the winPath is deterministic
+  process.env['USERPROFILE'] = 'C:\\Users\\testuser'
+})
+
+describe('getAccessToken', () => {
+  it('returns existing token when valid and not expiring', async () => {
+    const creds = buildCreds() // expiresAt is 1h from now
+    mockSingleCredFile(creds)
+
+    const token = await getAccessToken()
+
+    expect(token).toBe('valid-token')
+    expect(https.request).not.toHaveBeenCalled()
+  })
+
+  it('throws when no credential files are found', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+
+    await expect(getAccessToken()).rejects.toThrow('Claude credentials not found')
+  })
+
+  it('throws when accessToken is missing from credentials', async () => {
+    const creds = {
+      claudeAiOauth: {
+        accessToken: '',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      },
+    } as CredentialsFile
+    mockSingleCredFile(creds)
+
+    await expect(getAccessToken()).rejects.toThrow('missing accessToken')
+  })
+
+  it('triggers refresh when token expires in less than 5 minutes', async () => {
+    const creds = buildCreds({ expiresAt: Date.now() + 4 * 60 * 1000 }) // 4 min
+    mockSingleCredFile(creds)
+    mockHttpsRefreshResponse({
+      access_token: 'new-token',
+      refresh_token: 'new-refresh',
+      expires_in: 3600,
+    })
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined)
+
+    const token = await getAccessToken()
+
+    expect(https.request).toHaveBeenCalled()
+    expect(token).toBe('new-token')
+  })
+
+  it('refresh succeeds and returns new token', async () => {
+    const creds = buildCreds({ expiresAt: Date.now() + 4 * 60 * 1000 })
+    mockSingleCredFile(creds)
+    mockHttpsRefreshResponse({
+      access_token: 'new-token',
+      refresh_token: 'new-refresh',
+      expires_in: 3600,
+    })
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined)
+
+    const token = await getAccessToken()
+
+    expect(token).toBe('new-token')
+  })
+
+  it('falls back to existing token when refresh throws a network error', async () => {
+    const creds = buildCreds({ expiresAt: Date.now() + 4 * 60 * 1000 })
+    mockSingleCredFile(creds)
+    mockHttpsError(new Error('network failure'))
+
+    const token = await getAccessToken()
+
+    expect(token).toBe('valid-token')
+  })
+
+  it('falls back to existing token when refresh response is missing access_token', async () => {
+    const creds = buildCreds({ expiresAt: Date.now() + 4 * 60 * 1000 })
+    mockSingleCredFile(creds)
+    // Response body has no access_token — refreshToken will throw internally
+    mockHttpsRefreshResponse({})
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined)
+
+    const token = await getAccessToken()
+
+    // getAccessToken catches the throw from refreshToken and returns the old token
+    expect(token).toBe('valid-token')
+  })
+
+  it('selects the most recently modified file when multiple credential paths exist', async () => {
+    const olderCreds = buildCreds({ accessToken: 'older-token' })
+    const newerCreds = buildCreds({ accessToken: 'newer-token' })
+
+    const olderMtime = 1000
+    const newerMtime = 9000
+
+    // existsSync: winPath exists AND wslBase exists so we get a second candidate
+    vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+      const str = String(p)
+      if (str === '\\\\wsl.localhost') return true
+      // homeBase inside WSL distro
+      if (str.includes('home') && !str.includes('.credentials.json')) return true
+      // Both credential paths exist
+      if (str.includes('.credentials.json')) return true
+      return false
+    })
+
+    // readdirSync: one distro with one user
+    vi.mocked(fs.readdirSync).mockImplementation((p: fs.PathLike) => {
+      const str = String(p)
+      if (str === '\\\\wsl.localhost') return ['Ubuntu' as unknown as fs.Dirent]
+      if (str.includes('home')) return ['wsluser' as unknown as fs.Dirent]
+      return []
+    })
+
+    // statSync: windows path returns olderMtime, wsl path returns newerMtime
+    vi.mocked(fs.statSync).mockImplementation((p: fs.PathLike) => {
+      const str = String(p)
+      if (str.includes('wsluser')) return { mtimeMs: newerMtime } as ReturnType<typeof fs.statSync>
+      return { mtimeMs: olderMtime } as ReturnType<typeof fs.statSync>
+    })
+
+    // readFileSync: return different creds based on which path is read
+    vi.mocked(fs.readFileSync).mockImplementation((p: fs.PathLike | fs.promises.FileHandle) => {
+      const str = String(p)
+      if (str.includes('wsluser')) return JSON.stringify(newerCreds)
+      return JSON.stringify(olderCreds)
+    })
+
+    const token = await getAccessToken()
+
+    expect(token).toBe('newer-token')
+  })
+
+  it('does not check WSL paths when wslBase does not exist', async () => {
+    const creds = buildCreds()
+
+    vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+      const str = String(p)
+      if (str === '\\\\wsl.localhost') return false
+      if (str.includes('.credentials.json')) return true
+      return false
+    })
+    vi.mocked(fs.statSync).mockReturnValue({ mtimeMs: Date.now() } as ReturnType<typeof fs.statSync>)
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(creds))
+
+    await getAccessToken()
+
+    // readdirSync should never have been called since wslBase did not exist
+    expect(fs.readdirSync).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---- mock electron and settingsService before any imports -------------------
+
+const { mockNotificationShow, mockNotificationIsSupported, mockShellBeep, mockGetSettings, MockNotification } = vi.hoisted(() => {
+  const mockNotificationShow = vi.fn()
+  const MockNotification = vi.fn(function() { return { show: mockNotificationShow } })
+  return {
+    mockNotificationShow,
+    mockNotificationIsSupported: vi.fn(() => true),
+    mockShellBeep: vi.fn(),
+    mockGetSettings: vi.fn(),
+    MockNotification,
+  }
+})
+
+vi.mock('electron', () => ({
+  Notification: Object.assign(MockNotification, { isSupported: mockNotificationIsSupported }),
+  shell: { beep: mockShellBeep },
+}))
+
+vi.mock('../settingsService', () => ({ getSettings: mockGetSettings }))
+
+// ---- types ------------------------------------------------------------------
+
+import type { UsageData } from '../../models/usageData'
+
+// ---- lazy-imported module refs (reset per test via vi.resetModules) ----------
+
+let checkAndNotify: (data: UsageData) => void
+let syncWindowState: (data: UsageData) => void
+let sendTestNotification: () => void
+
+// ---- helpers ----------------------------------------------------------------
+
+type NotificationSettings = {
+  enabled: boolean
+  sessionThreshold: number
+  weeklyThreshold: number
+  resetThreshold: number
+  notifyOnReset: boolean
+  notifyOnWindowReset: boolean
+  soundEnabled: boolean
+}
+
+function defaultSettings(overrides: Partial<NotificationSettings> = {}): { notifications: NotificationSettings } {
+  return {
+    notifications: {
+      enabled: true,
+      sessionThreshold: 80,
+      weeklyThreshold: 80,
+      resetThreshold: 50,
+      notifyOnReset: false,
+      notifyOnWindowReset: true,
+      soundEnabled: true,
+      ...overrides,
+    },
+  }
+}
+
+function makeData(
+  sessionPct: number,
+  weeklyPct: number,
+  sessionResetsAt = '2026-03-26T12:00:00Z',
+  weeklyResetsAt = '2026-03-30T12:00:00Z'
+): UsageData {
+  return {
+    five_hour: { utilization: sessionPct, resets_at: sessionResetsAt },
+    seven_day: { utilization: weeklyPct, resets_at: weeklyResetsAt },
+  }
+}
+
+// ---- setup ------------------------------------------------------------------
+
+beforeEach(async () => {
+  // Reset module registry so module-level state (state, prevSessionResetsAt, etc.)
+  // starts fresh for every test.
+  vi.resetModules()
+
+  // Reset call history on the shared mock functions
+  mockNotificationShow.mockReset()
+  mockShellBeep.mockReset()
+  mockGetSettings.mockReset()
+  mockNotificationIsSupported.mockReset()
+  mockNotificationIsSupported.mockReturnValue(true)
+  MockNotification.mockClear()
+
+  // Re-import notificationService so module-level state is initialised fresh
+  const mod = await import('../notificationService')
+  checkAndNotify = mod.checkAndNotify
+  syncWindowState = mod.syncWindowState
+  sendTestNotification = mod.sendTestNotification
+})
+
+// ---- tests ------------------------------------------------------------------
+
+describe('checkAndNotify', () => {
+  it('sends no notification when notifications are disabled', () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ enabled: false }))
+
+    checkAndNotify(makeData(90, 90))
+
+    expect(mockNotificationShow).not.toHaveBeenCalled()
+  })
+
+  it('sends no notification when usage is below threshold', () => {
+    mockGetSettings.mockReturnValue(defaultSettings())
+
+    checkAndNotify(makeData(50, 50))
+
+    expect(mockNotificationShow).not.toHaveBeenCalled()
+  })
+
+  it('sends session limit warning when session crosses threshold', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings())
+
+    checkAndNotify(makeData(82, 50))
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+    // The Notification constructor receives the options; inspect its call args
+    const ctorCall = MockNotification.mock.calls[0][0] as { title: string }
+    expect(ctorCall.title).toContain('Session Limit Warning')
+  })
+
+  it('does not send duplicate session notification on subsequent calls', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings())
+
+    checkAndNotify(makeData(82, 50))
+    checkAndNotify(makeData(82, 50))
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends weekly limit warning when weekly crosses threshold', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings())
+
+    checkAndNotify(makeData(50, 82))
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+    const ctorCall = MockNotification.mock.calls[0][0] as { title: string }
+    expect(ctorCall.title).toContain('Weekly Limit Warning')
+  })
+
+  it('sends both session and weekly notifications when both cross threshold', () => {
+    mockGetSettings.mockReturnValue(defaultSettings())
+
+    checkAndNotify(makeData(82, 82))
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(2)
+  })
+
+  it('sends "Session Limit Freed" when usage drops below resetThreshold after being notified and notifyOnReset=true', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ notifyOnReset: true }))
+
+    // First call: cross threshold (sessionNotified = true)
+    checkAndNotify(makeData(82, 50))
+    mockNotificationShow.mockReset()
+    MockNotification.mockClear()
+
+    // Second call: drop below resetThreshold
+    checkAndNotify(makeData(30, 50))
+
+    const titles = MockNotification.mock.calls.map((c) => (c[0] as { title: string }).title)
+    expect(titles.some((t) => t.includes('Session Limit Freed'))).toBe(true)
+  })
+
+  it('does NOT send "Session Limit Freed" when notifyOnReset=false', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ notifyOnReset: false }))
+
+    checkAndNotify(makeData(82, 50))
+    mockNotificationShow.mockReset()
+    MockNotification.mockClear()
+
+    checkAndNotify(makeData(30, 50))
+
+    const titles = MockNotification.mock.calls.map((c) => (c[0] as { title: string }).title)
+    expect(titles.some((t) => t.includes('Session Limit Freed'))).toBe(false)
+  })
+
+  it('sends session window reset notification when resets_at changes, notifyOnWindowReset=true', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ notifyOnWindowReset: true }))
+
+    // First call establishes prevSessionResetsAt
+    checkAndNotify(makeData(50, 50, 'A', 'W1'))
+    mockNotificationShow.mockReset()
+    MockNotification.mockClear()
+
+    // Second call with different resets_at
+    checkAndNotify(makeData(50, 50, 'B', 'W1'))
+
+    const titles = MockNotification.mock.calls.map((c) => (c[0] as { title: string }).title)
+    expect(titles.some((t) => t.includes('Session Window Reset'))).toBe(true)
+  })
+
+  it('does NOT send session window reset notification when notifyOnWindowReset=false', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ notifyOnWindowReset: false }))
+
+    checkAndNotify(makeData(50, 50, 'A', 'W1'))
+    mockNotificationShow.mockReset()
+    MockNotification.mockClear()
+
+    checkAndNotify(makeData(50, 50, 'B', 'W1'))
+
+    expect(mockNotificationShow).not.toHaveBeenCalled()
+  })
+
+  it('does NOT send window reset notification on the very first call (prevSessionResetsAt is null)', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ notifyOnWindowReset: true }))
+
+    // First call ever — prevSessionResetsAt starts as null
+    checkAndNotify(makeData(50, 50, 'anything', 'anything'))
+
+    const titles = MockNotification.mock.calls.map((c) => (c[0] as { title: string }).title)
+    expect(titles.some((t) => t.includes('Window Reset'))).toBe(false)
+  })
+
+  it('syncWindowState prevents window reset notification when resets_at matches synced value', async () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ notifyOnWindowReset: true }))
+
+    const data = makeData(50, 50, '2026-03-26T12:00:00Z', '2026-03-30T12:00:00Z')
+
+    // syncWindowState sets prevSessionResetsAt to the same value as data
+    syncWindowState(data)
+
+    // checkAndNotify with the same resets_at → no change detected
+    checkAndNotify(data)
+
+    const titles = MockNotification.mock.calls.map((c) => (c[0] as { title: string }).title)
+    expect(titles.some((t) => t.includes('Window Reset'))).toBe(false)
+  })
+
+  it('calls shell.beep() before showing notification when soundEnabled=true', () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ soundEnabled: true }))
+
+    checkAndNotify(makeData(82, 50))
+
+    expect(mockShellBeep).toHaveBeenCalled()
+    expect(mockNotificationShow).toHaveBeenCalled()
+    // beep should come before show — check call order via invocation counts
+    // Both must have been called; ordering verified by the implementation always
+    // calling beep before new Notification().show()
+    expect(mockShellBeep.mock.invocationCallOrder[0]).toBeLessThan(
+      mockNotificationShow.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does NOT call shell.beep() when soundEnabled=false', () => {
+    mockGetSettings.mockReturnValue(defaultSettings({ soundEnabled: false }))
+
+    checkAndNotify(makeData(82, 50))
+
+    expect(mockShellBeep).not.toHaveBeenCalled()
+    expect(mockNotificationShow).toHaveBeenCalled()
+  })
+
+  it('shows no notification at all when Notification.isSupported() returns false', () => {
+    mockNotificationIsSupported.mockReturnValue(false)
+    mockGetSettings.mockReturnValue(defaultSettings())
+
+    checkAndNotify(makeData(82, 82))
+
+    expect(mockNotificationShow).not.toHaveBeenCalled()
+  })
+})
+
+describe('sendTestNotification', () => {
+  it('shows a notification when called', () => {
+    mockGetSettings.mockReturnValue(defaultSettings())
+
+    sendTestNotification()
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/services/__tests__/pollingService.test.ts
+++ b/src/services/__tests__/pollingService.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('electron', () => ({
+  powerMonitor: { getSystemIdleTime: vi.fn(() => 0) }
+}))
+
+const { mockFetch } = vi.hoisted(() => {
+  return { mockFetch: vi.fn() }
+})
+
+vi.mock('../../services/usageApiService', () => ({
+  fetchUsageData: mockFetch
+}))
+
+// Import after mocks are set up
+const { PollingService } = await import('../../services/pollingService')
+
+const FIVE_MIN_MS   = 5 * 60 * 1000
+const SEVEN_MIN_MS  = 7 * 60 * 1000
+const TWENTY_MIN_MS = 20 * 60 * 1000
+const ONE_MIN_MS    = 60 * 1000
+
+const makeData = (session = 0.5, weekly = 0.5) => ({
+  five_hour: { utilization: session, resets_at: '2026-03-26T12:00:00Z' },
+  seven_day: { utilization: weekly, resets_at: '2026-03-30T12:00:00Z' },
+})
+
+// Flush all pending microtasks (multiple ticks for async chains)
+async function flushPromises() {
+  for (let i = 0; i < 10; i++) await Promise.resolve()
+}
+
+describe('PollingService', () => {
+  let service: InstanceType<typeof PollingService>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockFetch.mockReset()
+    service = new PollingService()
+    // Suppress unhandled 'error' events so they don't throw in tests that don't listen
+    service.on('error', () => {})
+  })
+
+  afterEach(() => {
+    service.stop()
+    vi.useRealTimers()
+  })
+
+  // 1. restoreRateLimit with a future timestamp sets rateLimited
+  it('restoreRateLimit(future) prevents poll from fetching', async () => {
+    const future = Date.now() + 10 * 60 * 1000
+    service.restoreRateLimit(future, 2)
+
+    mockFetch.mockResolvedValue(makeData())
+    service.start()
+    await Promise.resolve()
+
+    // fetch should NOT have been called (rate limited)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  // 2. restoreRateLimit with a past timestamp does NOT set rateLimited
+  it('restoreRateLimit(past) does NOT block polling', async () => {
+    const past = Date.now() - 1000
+    service.restoreRateLimit(past, 2)
+
+    mockFetch.mockResolvedValue(makeData())
+    service.start()
+    await Promise.resolve()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  // 3. start() is idempotent
+  it('start() called twice does not double-poll', async () => {
+    mockFetch.mockResolvedValue(makeData())
+    service.start()
+    service.start()
+    await Promise.resolve()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  // 4. stop() clears timer and stops running
+  it('stop() prevents further polling', async () => {
+    mockFetch.mockResolvedValue(makeData())
+    service.start()
+    await Promise.resolve()
+    service.stop()
+
+    await vi.advanceTimersByTimeAsync(SEVEN_MIN_MS + 1000)
+    // Only 1 call from the initial poll
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  // 5. Successful fetch emits 'usage-updated'
+  it('successful fetch emits usage-updated', async () => {
+    const data = makeData()
+    mockFetch.mockResolvedValue(data)
+
+    const updates: unknown[] = []
+    service.on('usage-updated', (d) => updates.push(d))
+
+    service.start()
+    await Promise.resolve()
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toEqual(data)
+  })
+
+  // 5b. Successful fetch resets errorCount (returns to normal interval)
+  it('successful fetch resets errorCount to 0', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network error'))
+    mockFetch.mockResolvedValue(makeData())
+
+    service.start()
+    await Promise.resolve() // poll 1 → error, errorCount=1
+
+    // Advance 1min to trigger poll 2 (success, errorCount reset)
+    await vi.advanceTimersByTimeAsync(ONE_MIN_MS + 100)
+    await Promise.resolve()
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+
+    const calls = mockFetch.mock.calls.length
+
+    // After reset, next timer is NORMAL (7min), so no poll at 5min
+    await vi.advanceTimersByTimeAsync(FIVE_MIN_MS + 100)
+    expect(mockFetch).toHaveBeenCalledTimes(calls)
+    await vi.advanceTimersByTimeAsync(2 * ONE_MIN_MS)
+    await Promise.resolve()
+    expect(mockFetch).toHaveBeenCalledTimes(calls + 1)
+  })
+
+  // 6. Spike detection: session delta >1% → fast polling
+  it('session spike >1% triggers fast polling', async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeData(0.50, 0.50))
+      .mockResolvedValueOnce(makeData(0.52, 0.50)) // +2% session spike
+      .mockResolvedValue(makeData(0.52, 0.50))
+
+    service.start()
+    await Promise.resolve() // poll 1
+
+    await vi.advanceTimersByTimeAsync(SEVEN_MIN_MS + 100)
+    await Promise.resolve() // poll 2 → spike, fastCyclesLeft=2→1
+
+    const callsAfterSpike = mockFetch.mock.calls.length
+    await vi.advanceTimersByTimeAsync(FIVE_MIN_MS + 100)
+    await Promise.resolve()
+    expect(mockFetch).toHaveBeenCalledTimes(callsAfterSpike + 1)
+  })
+
+  // 7. Spike detection: weekly delta >1% → fast polling
+  it('weekly spike >1% triggers fast polling', async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeData(0.50, 0.50))
+      .mockResolvedValueOnce(makeData(0.50, 0.52)) // +2% weekly spike
+      .mockResolvedValue(makeData(0.50, 0.52))
+
+    service.start()
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(SEVEN_MIN_MS + 100)
+    await Promise.resolve()
+
+    const callsAfterSpike = mockFetch.mock.calls.length
+    await vi.advanceTimersByTimeAsync(FIVE_MIN_MS + 100)
+    await Promise.resolve()
+    expect(mockFetch).toHaveBeenCalledTimes(callsAfterSpike + 1)
+  })
+
+  // 8. No spike on first fetch (lastData=null)
+  it('first fetch does not trigger spike detection', async () => {
+    mockFetch.mockResolvedValue(makeData(0.99, 0.99))
+    service.start()
+    await Promise.resolve()
+
+    const calls = mockFetch.mock.calls.length
+    // No fast cycles — should not fire before 7min
+    await vi.advanceTimersByTimeAsync(FIVE_MIN_MS + 100)
+    expect(mockFetch).toHaveBeenCalledTimes(calls)
+    await vi.advanceTimersByTimeAsync(2 * ONE_MIN_MS)
+    await Promise.resolve()
+    expect(mockFetch).toHaveBeenCalledTimes(calls + 1)
+  })
+
+  // 9. 429 no headers → exponential backoff (count=1→5min, count=2→10min)
+  it('429 no headers uses exponential backoff', async () => {
+    const rl1 = Object.assign(new Error('Rate limited'), { isRateLimit: true })
+    const rl2 = Object.assign(new Error('Rate limited'), { isRateLimit: true })
+    mockFetch.mockRejectedValueOnce(rl1)
+    mockFetch.mockRejectedValueOnce(rl2)
+    mockFetch.mockResolvedValue(makeData())
+
+    const rateLimitedEvents: Array<[number, number, number | undefined]> = []
+    service.on('rate-limited', (until: number, count: number, resetAt: number | undefined) =>
+      rateLimitedEvents.push([until, count, resetAt])
+    )
+
+    service.start()
+    await Promise.resolve() // poll 1 → 429 (count=1, wait=5min)
+    expect(rateLimitedEvents).toHaveLength(1)
+    expect(rateLimitedEvents[0][1]).toBe(1)
+
+    const wait1 = rateLimitedEvents[0][0] - Date.now()
+    expect(wait1).toBeGreaterThan(4 * 60 * 1000)
+    expect(wait1).toBeLessThanOrEqual(5 * 60 * 1000)
+
+    // Advance past first rate limit period
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 100)
+    await Promise.resolve() // poll 2 → 429 (count=2, wait=10min)
+    expect(rateLimitedEvents).toHaveLength(2)
+    expect(rateLimitedEvents[1][1]).toBe(2)
+    const wait2 = rateLimitedEvents[1][0] - Date.now()
+    expect(wait2).toBeGreaterThan(9 * 60 * 1000)
+    expect(wait2).toBeLessThanOrEqual(10 * 60 * 1000)
+  })
+
+  // 10. 429 with retryAfterMs → uses retryAfterMs
+  it('429 with retryAfterMs uses the provided value', async () => {
+    const retryAfterMs = 3 * 60 * 1000
+    const rl = Object.assign(new Error('Rate limited'), { isRateLimit: true, retryAfterMs })
+    mockFetch.mockRejectedValueOnce(rl)
+    mockFetch.mockResolvedValue(makeData())
+
+    const rateLimitedEvents: Array<[number, number]> = []
+    service.on('rate-limited', (until: number, count: number) => rateLimitedEvents.push([until, count]))
+
+    service.start()
+    await Promise.resolve()
+    expect(rateLimitedEvents).toHaveLength(1)
+    const wait = rateLimitedEvents[0][0] - Date.now()
+    expect(wait).toBeGreaterThan(retryAfterMs - 500)
+    expect(wait).toBeLessThanOrEqual(retryAfterMs)
+  })
+
+  // 11. 429 with resetAt (future) → uses resetAt - Date.now()
+  it('429 with resetAt uses resetAt for wait time', async () => {
+    const resetAt = Date.now() + 8 * 60 * 1000
+    const rl = Object.assign(new Error('Rate limited'), { isRateLimit: true, resetAt })
+    mockFetch.mockRejectedValueOnce(rl)
+    mockFetch.mockResolvedValue(makeData())
+
+    const rateLimitedEvents: Array<[number, number, number | undefined]> = []
+    service.on('rate-limited', (until: number, count: number, rAt: number | undefined) =>
+      rateLimitedEvents.push([until, count, rAt])
+    )
+
+    service.start()
+    await Promise.resolve()
+    expect(rateLimitedEvents).toHaveLength(1)
+    expect(rateLimitedEvents[0][2]).toBe(resetAt)
+    const wait = rateLimitedEvents[0][0] - Date.now()
+    expect(wait).toBeGreaterThan(7 * 60 * 1000)
+    expect(wait).toBeLessThanOrEqual(8 * 60 * 1000)
+  })
+
+  // 12. 429 emits 'rate-limited' event
+  it('429 emits rate-limited event', async () => {
+    const rl = Object.assign(new Error('Rate limited'), { isRateLimit: true })
+    mockFetch.mockRejectedValueOnce(rl)
+    mockFetch.mockResolvedValue(makeData())
+
+    let rateLimitedFired = false
+    service.on('rate-limited', () => { rateLimitedFired = true })
+
+    service.start()
+    await Promise.resolve()
+    expect(rateLimitedFired).toBe(true)
+  })
+
+  // 13. Non-429 error increments errorCount and emits 'error', keeps running
+  it('non-429 error increments errorCount and emits error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network failure'))
+    mockFetch.mockResolvedValue(makeData())
+
+    const errors: Error[] = []
+    // Override the default no-op error listener
+    service.removeAllListeners('error')
+    service.on('error', (e: Error) => errors.push(e))
+
+    service.start()
+    await Promise.resolve()
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toBe('network failure')
+
+    // Service still running — next poll at 1min
+    await vi.advanceTimersByTimeAsync(ONE_MIN_MS + 100)
+    await Promise.resolve()
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  // 14. triggerNow() when rate limited → no-op
+  it('triggerNow() when rate limited skips poll', async () => {
+    const future = Date.now() + 10 * 60 * 1000
+    service.restoreRateLimit(future, 1)
+
+    await service.triggerNow()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  // 15. triggerNow() when NOT rate limited → calls poll
+  it('triggerNow() when not rate limited triggers poll', async () => {
+    mockFetch.mockResolvedValue(makeData())
+
+    service.start()
+    await Promise.resolve() // first poll
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    await service.triggerNow()
+    await Promise.resolve()
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  // 16. Error backoff intervals: verify timing by counting calls after each interval
+  it('errorCount=1 → 1min backoff, errorCount=2 → 2min, errorCount=8 → 20min cap', async () => {
+    mockFetch.mockRejectedValue(new Error('fail'))
+    service.start()
+    await flushPromises() // poll 1 fires at t=0, errorCount=1
+
+    // After 1min the second poll fires (errorCount=1 → 1min backoff)
+    await vi.advanceTimersByTimeAsync(ONE_MIN_MS + 1)
+    await flushPromises() // poll 2, errorCount=2
+    const afterPoll2 = mockFetch.mock.calls.length
+    expect(afterPoll2).toBeGreaterThanOrEqual(2)
+
+    // After 2min more the third poll fires (errorCount=2 → 2min backoff)
+    await vi.advanceTimersByTimeAsync(2 * ONE_MIN_MS + 1)
+    await flushPromises() // poll 3, errorCount=3
+    expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(afterPoll2 + 1)
+
+    // Advance through errorCounts 3→8 (backoffs: 4min, 8min, 16min cap at 20min, 20min, 20min)
+    for (let i = 3; i < 8; i++) {
+      const backoff = Math.min(ONE_MIN_MS * Math.pow(2, i - 1), TWENTY_MIN_MS)
+      await vi.advanceTimersByTimeAsync(backoff + 1)
+      await flushPromises()
+    }
+    // At errorCount=8, cap is 20min
+    const callsBefore20min = mockFetch.mock.calls.length
+
+    // Verify 20min cap: poll fires after 20min, not before
+    // We advance just under 20min and confirm no extra poll yet
+    // (Note: we already advanced past the previous timer, so the new 20min timer was just set)
+    await vi.advanceTimersByTimeAsync(TWENTY_MIN_MS + 1)
+    await flushPromises()
+    expect(mockFetch.mock.calls.length).toBe(callsBefore20min + 1)
+  })
+
+  // 17. Success after error resets errorCount to 0
+  it('success after error resets errorCount to 0', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('fail'))
+    mockFetch.mockResolvedValue(makeData())
+
+    service.start()
+    await Promise.resolve() // poll 1 → error, errorCount=1
+
+    await vi.advanceTimersByTimeAsync(ONE_MIN_MS + 100)
+    await Promise.resolve() // poll 2 → success, errorCount=0
+
+    const calls = mockFetch.mock.calls.length
+
+    // Next interval back to NORMAL (7min)
+    await vi.advanceTimersByTimeAsync(FIVE_MIN_MS + 100)
+    expect(mockFetch).toHaveBeenCalledTimes(calls)
+    await vi.advanceTimersByTimeAsync(2 * ONE_MIN_MS)
+    await Promise.resolve()
+    expect(mockFetch).toHaveBeenCalledTimes(calls + 1)
+  })
+})

--- a/src/services/__tests__/settingsService.test.ts
+++ b/src/services/__tests__/settingsService.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.hoisted ensures storeData is available inside the vi.mock factory
+const { storeRef } = vi.hoisted(() => {
+  const storeRef = { data: {} as Record<string, unknown> }
+  return { storeRef }
+})
+
+vi.mock('electron-store', () => {
+  return {
+    default: vi.fn(function({ defaults }: { defaults: Record<string, unknown> }) {
+      storeRef.data = { ...defaults }
+      return {
+        get: vi.fn((key: string, defaultVal: unknown) => {
+          return key in storeRef.data ? storeRef.data[key] : defaultVal
+        }),
+        set: vi.fn((key: string, value: unknown) => {
+          storeRef.data[key] = value
+        }),
+      }
+    }),
+  }
+})
+
+import { getSettings, saveSettings } from '../settingsService'
+
+const defaultNotifications = {
+  enabled: true,
+  sessionThreshold: 80,
+  weeklyThreshold: 80,
+  resetThreshold: 50,
+  notifyOnReset: false,
+  notifyOnWindowReset: true,
+  soundEnabled: true,
+}
+
+beforeEach(() => {
+  // Reset to empty so getSettings() falls back to the hardcoded defaults in the service
+  storeRef.data = {}
+})
+
+describe('getSettings()', () => {
+  it('returns all defaults when no data has been saved', () => {
+    const settings = getSettings()
+
+    expect(settings.launchAtStartup).toBe(false)
+    expect(settings.alwaysVisible).toBe(false)
+    expect(settings.theme).toBe('system')
+    expect(settings.language).toBe('en')
+    expect(settings.pollIntervalMinutes).toBe(7)
+    expect(settings.windowSize).toBe('large')
+    expect(settings.autoRefresh).toBe(false)
+    expect(settings.autoRefreshInterval).toBe(300)
+    expect(settings.rateLimitedUntil).toBe(0)
+    expect(settings.rateLimitCount).toBe(0)
+    expect(settings.rateLimitResetAt).toBe(0)
+    expect(settings.notifications.enabled).toBe(true)
+    expect(settings.notifications.sessionThreshold).toBe(80)
+    expect(settings.notifications.weeklyThreshold).toBe(80)
+    expect(settings.notifications.soundEnabled).toBe(true)
+  })
+})
+
+describe('saveSettings()', () => {
+  it('updating a single key updates only that key and leaves others at defaults', () => {
+    saveSettings({ theme: 'dark' })
+
+    const settings = getSettings()
+    expect(settings.theme).toBe('dark')
+    expect(settings.language).toBe('en')
+  })
+
+  it('updating multiple keys in one call updates all of them', () => {
+    saveSettings({ theme: 'light', language: 'pt-BR', pollIntervalMinutes: 5 })
+
+    const settings = getSettings()
+    expect(settings.theme).toBe('light')
+    expect(settings.language).toBe('pt-BR')
+    expect(settings.pollIntervalMinutes).toBe(5)
+  })
+
+  it('saving a partial notifications object replaces the notifications block', () => {
+    saveSettings({
+      notifications: { ...defaultNotifications, sessionThreshold: 90 },
+    })
+
+    const settings = getSettings()
+    expect(settings.notifications.sessionThreshold).toBe(90)
+    // Other notification fields remain as supplied
+    expect(settings.notifications.enabled).toBe(true)
+    expect(settings.notifications.weeklyThreshold).toBe(80)
+  })
+
+  it('getSettings() after save returns the updated value', () => {
+    saveSettings({ launchAtStartup: true })
+
+    expect(getSettings().launchAtStartup).toBe(true)
+  })
+
+  it('persists rateLimitedUntil and rateLimitCount', () => {
+    saveSettings({ rateLimitedUntil: 9999999, rateLimitCount: 3 })
+
+    const settings = getSettings()
+    expect(settings.rateLimitedUntil).toBe(9999999)
+    expect(settings.rateLimitCount).toBe(3)
+  })
+
+  it('passing undefined for a key does NOT overwrite the previously saved value', () => {
+    saveSettings({ theme: 'dark' })
+    saveSettings({ theme: undefined as unknown as 'dark' | 'light' | 'system' })
+
+    expect(getSettings().theme).toBe('dark')
+  })
+
+  it('multiple saves in succession all persist', () => {
+    saveSettings({ theme: 'dark' })
+    saveSettings({ language: 'pt-BR' })
+    saveSettings({ pollIntervalMinutes: 3 })
+
+    const settings = getSettings()
+    expect(settings.theme).toBe('dark')
+    expect(settings.language).toBe('pt-BR')
+    expect(settings.pollIntervalMinutes).toBe(3)
+  })
+})

--- a/src/services/__tests__/startupService.test.ts
+++ b/src/services/__tests__/startupService.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockIsEnabled, mockEnable, mockDisable } = vi.hoisted(() => ({
+  mockIsEnabled: vi.fn(),
+  mockEnable: vi.fn(),
+  mockDisable: vi.fn(),
+}))
+
+vi.mock('auto-launch', () => ({
+  default: vi.fn(function() {
+    return {
+      isEnabled: mockIsEnabled,
+      enable: mockEnable,
+      disable: mockDisable,
+    }
+  }),
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn().mockReturnValue('/mock/app.exe') },
+}))
+
+import { setLaunchAtStartup, isLaunchAtStartupEnabled } from '../startupService'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('setLaunchAtStartup()', () => {
+  it('calls enable() when requested to enable and currently disabled', async () => {
+    mockIsEnabled.mockResolvedValue(false)
+
+    await setLaunchAtStartup(true)
+
+    expect(mockEnable).toHaveBeenCalledOnce()
+    expect(mockDisable).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call enable() when already enabled', async () => {
+    mockIsEnabled.mockResolvedValue(true)
+
+    await setLaunchAtStartup(true)
+
+    expect(mockEnable).not.toHaveBeenCalled()
+  })
+
+  it('calls disable() when requested to disable and currently enabled', async () => {
+    mockIsEnabled.mockResolvedValue(true)
+
+    await setLaunchAtStartup(false)
+
+    expect(mockDisable).toHaveBeenCalledOnce()
+    expect(mockEnable).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call disable() when already disabled', async () => {
+    mockIsEnabled.mockResolvedValue(false)
+
+    await setLaunchAtStartup(false)
+
+    expect(mockDisable).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when autoLauncher throws — error is swallowed internally', async () => {
+    mockIsEnabled.mockRejectedValue(new Error('permission denied'))
+
+    await expect(setLaunchAtStartup(true)).resolves.not.toThrow()
+  })
+})
+
+describe('isLaunchAtStartupEnabled()', () => {
+  it('returns true when the auto-launcher reports enabled', async () => {
+    mockIsEnabled.mockResolvedValue(true)
+
+    expect(await isLaunchAtStartupEnabled()).toBe(true)
+  })
+
+  it('returns false when the auto-launcher reports disabled', async () => {
+    mockIsEnabled.mockResolvedValue(false)
+
+    expect(await isLaunchAtStartupEnabled()).toBe(false)
+  })
+
+  it('returns false when isEnabled() throws', async () => {
+    mockIsEnabled.mockRejectedValue(new Error('registry error'))
+
+    expect(await isLaunchAtStartupEnabled()).toBe(false)
+  })
+})

--- a/src/services/__tests__/usageApiService.test.ts
+++ b/src/services/__tests__/usageApiService.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('electron', () => ({}))
+
+const mockExecSync = vi.fn()
+vi.mock('child_process', () => ({ execSync: mockExecSync }))
+
+const mockGetAccessToken = vi.fn()
+vi.mock('../../services/credentialService', () => ({ getAccessToken: mockGetAccessToken }))
+
+const mockRequest = vi.fn()
+vi.mock('https', () => ({ request: mockRequest }))
+
+function makeFakeReq() {
+  return {
+    on: vi.fn(),
+    end: vi.fn(),
+    setTimeout: vi.fn(),
+    destroy: vi.fn(),
+    write: vi.fn(),
+  }
+}
+
+type OnFn = (event: string, handler: (...args: unknown[]) => void) => void
+
+function setupHttpsResponse(
+  statusCode: number,
+  body: string,
+  headers: Record<string, string> = {}
+) {
+  const req = makeFakeReq()
+  const resOn: OnFn = (event, handler) => {
+    if (event === 'data') handler(body)
+    if (event === 'end') handler()
+  }
+  const res = { statusCode, headers, on: vi.fn(resOn) }
+
+  mockRequest.mockImplementation((_opts: unknown, cb: (r: typeof res) => void) => {
+    cb(res)
+    return req
+  })
+
+  return { req, res }
+}
+
+const makeUsageData = () => ({
+  five_hour: { utilization: 0.5, resets_at: '2026-03-26T12:00:00Z' },
+  seven_day: { utilization: 0.3, resets_at: '2026-03-30T12:00:00Z' },
+})
+
+// MAX_RETRIES = 5; advance all backoff sleeps to exhaust retries
+async function exhaustRetries() {
+  for (let i = 0; i < 5; i++) {
+    const backoff = Math.min(1000 * Math.pow(2, i), 16000)
+    await vi.advanceTimersByTimeAsync(backoff + 100)
+  }
+}
+
+describe('usageApiService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    mockRequest.mockReset()
+    mockExecSync.mockReset()
+    mockGetAccessToken.mockReset()
+    mockGetAccessToken.mockResolvedValue('test-token')
+    mockExecSync.mockReturnValue('claude 2.1.0')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function importFetchUsageData() {
+    const mod = await import('../../services/usageApiService')
+    return mod.fetchUsageData
+  }
+
+  // 1. 200 with valid data → returns UsageData
+  it('200 with valid data returns UsageData', async () => {
+    const data = makeUsageData()
+    setupHttpsResponse(200, JSON.stringify(data))
+
+    const fetchUsageData = await importFetchUsageData()
+    const result = await fetchUsageData()
+    expect(result).toEqual(data)
+  })
+
+  // 2. 200 with missing five_hour → throws after all retries
+  it('200 with missing five_hour throws shape error', async () => {
+    const data = { seven_day: { utilization: 0.3, resets_at: '2026-03-30T12:00:00Z' } }
+    setupHttpsResponse(200, JSON.stringify(data))
+
+    const fetchUsageData = await importFetchUsageData()
+    const promise = fetchUsageData()
+    // Attach assertion before advancing timers so rejection is handled immediately
+    const assertion = expect(promise).rejects.toThrow('Unexpected API response shape')
+    await exhaustRetries()
+    await assertion
+  })
+
+  // 3. 200 with missing seven_day → throws after all retries
+  it('200 with missing seven_day throws shape error', async () => {
+    const data = { five_hour: { utilization: 0.5, resets_at: '2026-03-26T12:00:00Z' } }
+    setupHttpsResponse(200, JSON.stringify(data))
+
+    const fetchUsageData = await importFetchUsageData()
+    const promise = fetchUsageData()
+    const assertion = expect(promise).rejects.toThrow('Unexpected API response shape')
+    await exhaustRetries()
+    await assertion
+  })
+
+  // 4. 429 no headers → throws with isRateLimit=true, no retryAfterMs, no resetAt
+  it('429 no headers throws with isRateLimit=true', async () => {
+    setupHttpsResponse(429, 'rate limited')
+
+    const fetchUsageData = await importFetchUsageData()
+    let thrown: unknown
+    try {
+      await fetchUsageData()
+    } catch (e) {
+      thrown = e
+    }
+
+    expect(thrown).toBeDefined()
+    expect((thrown as { isRateLimit?: boolean }).isRateLimit).toBe(true)
+    expect((thrown as { retryAfterMs?: number }).retryAfterMs).toBeUndefined()
+    expect((thrown as { resetAt?: number }).resetAt).toBeUndefined()
+  })
+
+  // 5. 429 with retry-after header → retryAfterMs = retryAfter * 1000
+  it('429 with retry-after header sets retryAfterMs', async () => {
+    setupHttpsResponse(429, 'rate limited', { 'retry-after': '120' })
+
+    const fetchUsageData = await importFetchUsageData()
+    let thrown: unknown
+    try {
+      await fetchUsageData()
+    } catch (e) {
+      thrown = e
+    }
+
+    expect((thrown as { isRateLimit?: boolean }).isRateLimit).toBe(true)
+    expect((thrown as { retryAfterMs?: number }).retryAfterMs).toBe(120 * 1000)
+    expect((thrown as { resetAt?: number }).resetAt).toBeUndefined()
+  })
+
+  // 6. 429 with reset headers → resetAt = max of headers, retryAfterMs = resetAt - Date.now()
+  it('429 with reset headers computes resetAt from max header', async () => {
+    const now = Date.now()
+    const resetTime1 = new Date(now + 5 * 60 * 1000).toISOString()
+    const resetTime2 = new Date(now + 8 * 60 * 1000).toISOString()
+
+    setupHttpsResponse(429, 'rate limited', {
+      'anthropic-ratelimit-requests-reset': resetTime1,
+      'anthropic-ratelimit-tokens-reset': resetTime2,
+    })
+
+    const fetchUsageData = await importFetchUsageData()
+    let thrown: unknown
+    try {
+      await fetchUsageData()
+    } catch (e) {
+      thrown = e
+    }
+
+    expect((thrown as { isRateLimit?: boolean }).isRateLimit).toBe(true)
+    const resetAt = (thrown as { resetAt?: number }).resetAt
+    expect(resetAt).toBeDefined()
+    expect(resetAt!).toBeGreaterThan(now + 7 * 60 * 1000)
+    expect(resetAt!).toBeLessThanOrEqual(now + 8 * 60 * 1000 + 100)
+
+    const retryAfterMs = (thrown as { retryAfterMs?: number }).retryAfterMs
+    expect(retryAfterMs).toBeDefined()
+    expect(retryAfterMs!).toBeGreaterThan(7 * 60 * 1000)
+    expect(retryAfterMs!).toBeLessThanOrEqual(8 * 60 * 1000 + 100)
+  })
+
+  // 7. 401 first attempt → retries (second call succeeds)
+  it('401 on first attempt retries and returns data on second', async () => {
+    const data = makeUsageData()
+    let callCount = 0
+
+    mockRequest.mockImplementation((_opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      const statusCode = callCount === 1 ? 401 : 200
+      const body = callCount === 1 ? 'unauthorized' : JSON.stringify(data)
+      const res = {
+        statusCode,
+        headers: {},
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          if (event === 'data') handler(body)
+          if (event === 'end') handler()
+        }),
+      }
+      cb(res)
+      return makeFakeReq()
+    })
+
+    const fetchUsageData = await importFetchUsageData()
+    const resultPromise = fetchUsageData()
+
+    // flush the 500ms sleep after 401
+    await vi.advanceTimersByTimeAsync(600)
+    const result = await resultPromise
+
+    expect(result).toEqual(data)
+    expect(callCount).toBe(2)
+  })
+
+  // 8. 401 both attempts → throws Authentication failed
+  it('401 on both attempts throws Authentication failed', async () => {
+    let callCount = 0
+    mockRequest.mockImplementation((_opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      const res = {
+        statusCode: 401,
+        headers: {},
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          if (event === 'data') handler('unauthorized')
+          if (event === 'end') handler()
+        }),
+      }
+      cb(res)
+      return makeFakeReq()
+    })
+
+    const fetchUsageData = await importFetchUsageData()
+    const resultPromise = fetchUsageData()
+    const assertion = expect(resultPromise).rejects.toThrow('Authentication failed')
+    await vi.advanceTimersByTimeAsync(600)
+
+    await assertion
+    expect(callCount).toBe(2)
+  })
+
+  // 9. 500 → retries with exponential backoff, eventually throws
+  it('500 retries with exponential backoff then throws', async () => {
+    let callCount = 0
+    mockRequest.mockImplementation((_opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      const res = {
+        statusCode: 500,
+        headers: {},
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          if (event === 'data') handler('server error')
+          if (event === 'end') handler()
+        }),
+      }
+      cb(res)
+      return makeFakeReq()
+    })
+
+    const fetchUsageData = await importFetchUsageData()
+    const resultPromise = fetchUsageData()
+    const assertion = expect(resultPromise).rejects.toThrow('API returned 500')
+
+    await exhaustRetries()
+
+    await assertion
+    expect(callCount).toBe(5)
+  })
+
+  // 10. Network error → retries, eventually throws
+  it('network error retries then throws', async () => {
+    let callCount = 0
+    mockRequest.mockImplementation((_opts: unknown, _cb: unknown) => {
+      callCount++
+      const req = makeFakeReq()
+      req.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'error') {
+          // Fire error synchronously to avoid timer complications
+          handler(new Error('ECONNREFUSED'))
+        }
+      })
+      return req
+    })
+
+    const fetchUsageData = await importFetchUsageData()
+    const resultPromise = fetchUsageData()
+    const assertion = expect(resultPromise).rejects.toThrow()
+
+    await exhaustRetries()
+
+    await assertion
+    expect(callCount).toBe(5)
+  })
+
+  // 11. getClaudeVersion falls back to '2.0.0' when execSync throws
+  it('getClaudeVersion falls back to 2.0.0 when execSync throws', async () => {
+    mockExecSync.mockImplementation(() => { throw new Error('claude not found') })
+
+    const data = makeUsageData()
+    let capturedHeaders: Record<string, string> = {}
+
+    mockRequest.mockImplementation((opts: { headers: Record<string, string> }, cb: (res: unknown) => void) => {
+      capturedHeaders = opts.headers
+      const res = {
+        statusCode: 200,
+        headers: {},
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          if (event === 'data') handler(JSON.stringify(data))
+          if (event === 'end') handler()
+        }),
+      }
+      cb(res)
+      return makeFakeReq()
+    })
+
+    const fetchUsageData = await importFetchUsageData()
+    await fetchUsageData()
+
+    expect(capturedHeaders['User-Agent']).toBe('claude-code/2.0.0')
+  })
+
+  // 12. getClaudeVersion parses version string from execSync output
+  it('getClaudeVersion parses version string from execSync', async () => {
+    mockExecSync.mockReturnValue('claude/3.5.1 (build 42)')
+
+    const data = makeUsageData()
+    let capturedHeaders: Record<string, string> = {}
+
+    mockRequest.mockImplementation((opts: { headers: Record<string, string> }, cb: (res: unknown) => void) => {
+      capturedHeaders = opts.headers
+      const res = {
+        statusCode: 200,
+        headers: {},
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          if (event === 'data') handler(JSON.stringify(data))
+          if (event === 'end') handler()
+        }),
+      }
+      cb(res)
+      return makeFakeReq()
+    })
+
+    const fetchUsageData = await importFetchUsageData()
+    await fetchUsageData()
+
+    expect(capturedHeaders['User-Agent']).toBe('claude-code/3.5.1')
+  })
+})

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/main.ts", "src/preload.ts", "src/services/**/*", "src/models/**/*"],
-  "exclude": ["node_modules", "dist", "src/renderer"]
+  "exclude": ["node_modules", "dist", "src/renderer", "src/services/__tests__/**", "src/**/*.test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.main.json",
+  "include": ["src/**/*.ts", "vitest.config.ts"],
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    exclude: ['dist/**', 'node_modules/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/services/**/*.ts'],
+      exclude: ['src/services/__tests__/**'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Instala Vitest + @vitest/coverage-v8 como devDependencies
- Adiciona `vitest.config.ts` e `tsconfig.test.json`
- 71 testes unitários cobrindo todos os 6 serviços
- Pre-push git hook bloqueia push se testes falharem

## Scenarios Covered
- **pollingService** (17 testes): start/stop idempotente, spike detection, rate limit backoff exponencial, triggerNow, idle mode, error backoff capped at 20min
- **usageApiService** (12 testes): 200/401/429/500 handling, retry exponencial, retryAfterMs/resetAt parsing, fallback version '2.0.0'
- **credentialService** (9 testes): token válido/expirando, refresh ok/falha, múltiplos arquivos (mtime), arquivo ausente, accessToken missing
- **notificationService** (16 testes): threshold crossing, dedup, window reset, freed notification, sound, disabled, Notification.isSupported=false
- **settingsService** (8 testes): defaults, save parcial, multi-key save, undefined guard, round-trip
- **startupService** (8 testes): enable/disable, idempotência, swallowed errors, isEnabled fallback

## Coverage Gaps
- `main.ts` (IPC handlers, window positioning) — requer Electron real, fora de escopo
- `renderer/app.ts` (Chart.js, canvas) — requer browser environment
- Testes E2E

## Related
Closes #1

## Test plan
- [x] `npm test` — 71 testes passando
- [x] `npm run build` — build limpo
- [x] Pre-push hook em `.git/hooks/pre-push` bloqueia push se testes falharem

🤖 Generated with [Claude Code](https://claude.com/claude-code)