### PR TITLE
fix: stop window reset notifications from firing every poll cycle

### DIFF
--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -181,12 +181,12 @@ describe('checkAndNotify', () => {
     mockGetSettings.mockReturnValue(defaultSettings({ notifyOnWindowReset: true }))
 
     // First call establishes prevSessionResetsAt
-    checkAndNotify(makeData(50, 50, 'A', 'W1'))
+    checkAndNotify(makeData(50, 50, '2026-03-26T10:00:00Z', 'W1'))
     mockNotificationShow.mockReset()
     MockNotification.mockClear()
 
-    // Second call with different resets_at
-    checkAndNotify(makeData(50, 50, 'B', 'W1'))
+    // Second call with resets_at advanced by 2 hours (genuine window reset)
+    checkAndNotify(makeData(50, 50, '2026-03-26T12:00:00Z', 'W1'))
 
     const titles = MockNotification.mock.calls.map((c) => (c[0] as { title: string }).title)
     expect(titles.some((t) => t.includes('Session Window Reset'))).toBe(true)
@@ -195,11 +195,11 @@ describe('checkAndNotify', () => {
   it('does NOT send session window reset notification when notifyOnWindowReset=false', async () => {
     mockGetSettings.mockReturnValue(defaultSettings({ notifyOnWindowReset: false }))
 
-    checkAndNotify(makeData(50, 50, 'A', 'W1'))
+    checkAndNotify(makeData(50, 50, '2026-03-26T10:00:00Z', 'W1'))
     mockNotificationShow.mockReset()
     MockNotification.mockClear()
 
-    checkAndNotify(makeData(50, 50, 'B', 'W1'))
+    checkAndNotify(makeData(50, 50, '2026-03-26T12:00:00Z', 'W1'))
 
     expect(mockNotificationShow).not.toHaveBeenCalled()
   })

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -41,6 +41,12 @@ export function sendTestNotification(): void {
   );
 }
 
+function isSignificantReset(prevAt: string, newAt: string, minGapMs: number): boolean {
+  const prev = new Date(prevAt).getTime();
+  const next = new Date(newAt).getTime();
+  return !isNaN(prev) && !isNaN(next) && (next - prev) > minGapMs;
+}
+
 export function checkAndNotify(data: UsageData): void {
   const settings = getSettings();
   if (!settings.notifications.enabled) return;
@@ -55,7 +61,7 @@ export function checkAndNotify(data: UsageData): void {
   const weeklyPct  = Math.round(data.seven_day.utilization);
 
   // Detect time-window reset (resets_at changed to a new value)
-  if (prevSessionResetsAt !== null && data.five_hour.resets_at !== prevSessionResetsAt) {
+  if (prevSessionResetsAt !== null && isSignificantReset(prevSessionResetsAt, data.five_hour.resets_at, 60 * 60 * 1000)) {
     if (notifyOnWindowReset) {
       showToast('Claude — Session Window Reset', 'Your 5-hour usage window has reset', soundEnabled);
     }
@@ -63,7 +69,7 @@ export function checkAndNotify(data: UsageData): void {
   }
   prevSessionResetsAt = data.five_hour.resets_at;
 
-  if (prevWeeklyResetsAt !== null && data.seven_day.resets_at !== prevWeeklyResetsAt) {
+  if (prevWeeklyResetsAt !== null && isSignificantReset(prevWeeklyResetsAt, data.seven_day.resets_at, 24 * 60 * 60 * 1000)) {
     if (notifyOnWindowReset) {
       showToast('Claude — Weekly Window Reset', 'Your weekly usage window has reset', soundEnabled);
     }


### PR DESCRIPTION
## Summary
- \"Session Window Reset\" and \"Weekly Window Reset\" notifications were firing every ~7 min (every polling cycle)
- Root cause: Anthropic API returns \`resets_at\` as a freshly computed timestamp that drifts by seconds each call; the old \`!==\` string check triggered on every drift
- Fix: replaced strict equality with \`isSignificantReset()\` — only fires when new \`resets_at\` is ≥1 hour later (session) or ≥24 hours later (weekly) than previous value

## Root Cause
\`resets_at\` ≈ \"now + window duration\" on every API response → tiny drift → \`!==\` always true → toast on every poll.

## Related
Closes #3

## Test plan
- [x] \`npm run build\` exits cleanly
- [x] All 71 unit tests pass (6 test files)
- [ ] Run app for 2+ polling cycles — no spurious Window Reset toasts appear
- [ ] Wait for genuine 5-hour window rollover — exactly one Session Window Reset toast fires
- [ ] Verify Session Limit Warning still fires correctly after window reset (flag reset path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)