### PR TITLE
feat: show reset time in tray tooltip

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -106,11 +106,28 @@ function buildTrayIcon(): Electron.NativeImage {
   return nativeImage.createEmpty();
 }
 
+function formatTimeUntil(isoDate: string): string {
+  const diffMs = new Date(isoDate).getTime() - Date.now();
+  if (diffMs <= 0) return 'soon';
+  const totalMinutes = Math.floor(diffMs / 60000);
+  const days    = Math.floor(totalMinutes / 1440);
+  const hours   = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  if (days > 0)  return hours > 0  ? `${days}d ${hours}h`  : `${days}d`;
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  return `${minutes}m`;
+}
+
 function updateTrayTooltip(data: UsageData): void {
   if (!tray) return;
-  const sessionPct = Math.round(data.five_hour.utilization);
-  const weeklyPct  = Math.round(data.seven_day.utilization);
-  tray.setToolTip(`Claude Usage — Session: ${sessionPct}% | Weekly: ${weeklyPct}%`);
+  const sessionPct     = Math.round(data.five_hour.utilization);
+  const weeklyPct      = Math.round(data.seven_day.utilization);
+  const sessionResets  = formatTimeUntil(data.five_hour.resets_at);
+  const weeklyResets   = formatTimeUntil(data.seven_day.resets_at);
+  tray.setToolTip(
+    `Claude Usage — Session: ${sessionPct}% | Weekly: ${weeklyPct}%\n` +
+    `Session resets in: ${sessionResets} | Weekly resets in: ${weeklyResets}`
+  );
 }
 
 function buildContextMenu(): Menu {


### PR DESCRIPTION
## Summary
- Add `formatTimeUntil()` helper that converts ISO datetime to human-readable countdown
- Update tray tooltip to show a second line with session and weekly reset times

**Before:** `Claude Usage — Session: 16% | Weekly: 24%`

**After:**
```
Claude Usage — Session: 16% | Weekly: 24%
Session resets in: 2h 30m | Weekly resets in: 3d 4h
```

## Related
Closes #7

## Test plan
- [ ] `npm run build` exits cleanly
- [ ] Hover tray icon — tooltip shows two lines with reset times
- [ ] Reset times count down correctly (Xd Xh / Xh Xm / Xm / soon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)