### PR TITLE
fix: translate notifications and tray menu to respect language setting

### DIFF
--- a/src/i18n/mainTranslations.ts
+++ b/src/i18n/mainTranslations.ts
@@ -1,0 +1,73 @@
+export interface MainTranslations {
+  notifTestTitle: string;
+  notifTestBody: string;
+  notifSessionWindowResetTitle: string;
+  notifSessionWindowResetBody: string;
+  notifWeeklyWindowResetTitle: string;
+  notifWeeklyWindowResetBody: string;
+  notifSessionFreedTitle: string;
+  notifSessionFreedBody: (pct: number) => string;
+  notifWeeklyFreedTitle: string;
+  notifWeeklyFreedBody: (pct: number) => string;
+  notifSessionWarnTitle: string;
+  notifSessionWarnBody: (pct: number, threshold: number) => string;
+  notifWeeklyWarnTitle: string;
+  notifWeeklyWarnBody: (pct: number, threshold: number) => string;
+  trayInitialTooltip: string;
+  trayTooltipLine1: (sessionPct: string, weeklyPct: string) => string;
+  trayTooltipLine2: (sessionResets: string, weeklyResets: string) => string;
+  trayRefreshNow: string;
+  trayLaunchAtStartup: string;
+  trayExit: string;
+}
+
+const en: MainTranslations = {
+  notifTestTitle: 'Claude — Test Notification',
+  notifTestBody: 'Notifications are working correctly',
+  notifSessionWindowResetTitle: 'Claude — Session Window Reset',
+  notifSessionWindowResetBody: 'Your 5-hour usage window has reset',
+  notifWeeklyWindowResetTitle: 'Claude — Weekly Window Reset',
+  notifWeeklyWindowResetBody: 'Your weekly usage window has reset',
+  notifSessionFreedTitle: 'Claude — Session Limit Freed',
+  notifSessionFreedBody: (pct) => `Session usage dropped to ${pct}% — limit has reset`,
+  notifWeeklyFreedTitle: 'Claude — Weekly Limit Freed',
+  notifWeeklyFreedBody: (pct) => `Weekly usage dropped to ${pct}% — limit has reset`,
+  notifSessionWarnTitle: 'Claude — Session Limit Warning',
+  notifSessionWarnBody: (pct, threshold) => `Session usage is at ${pct}% (${threshold}% threshold reached)`,
+  notifWeeklyWarnTitle: 'Claude — Weekly Limit Warning',
+  notifWeeklyWarnBody: (pct, threshold) => `Weekly usage is at ${pct}% (${threshold}% threshold reached)`,
+  trayInitialTooltip: 'Claude Usage Monitor',
+  trayTooltipLine1: (sessionPct, weeklyPct) => `Claude Usage — Session: ${sessionPct}% | Weekly: ${weeklyPct}%`,
+  trayTooltipLine2: (sessionResets, weeklyResets) => `Session resets in: ${sessionResets} | Weekly resets in: ${weeklyResets}`,
+  trayRefreshNow: 'Refresh Now',
+  trayLaunchAtStartup: 'Launch at Startup',
+  trayExit: 'Exit',
+};
+
+const ptBR: MainTranslations = {
+  notifTestTitle: 'Claude — Notificação de Teste',
+  notifTestBody: 'As notificações estão funcionando corretamente',
+  notifSessionWindowResetTitle: 'Claude — Sessão Reiniciada',
+  notifSessionWindowResetBody: 'Sua janela de uso de 5 horas foi reiniciada',
+  notifWeeklyWindowResetTitle: 'Claude — Semana Reiniciada',
+  notifWeeklyWindowResetBody: 'Sua janela de uso semanal foi reiniciada',
+  notifSessionFreedTitle: 'Claude — Limite de Sessão Liberado',
+  notifSessionFreedBody: (pct) => `Uso da sessão caiu para ${pct}% — limite foi liberado`,
+  notifWeeklyFreedTitle: 'Claude — Limite Semanal Liberado',
+  notifWeeklyFreedBody: (pct) => `Uso semanal caiu para ${pct}% — limite foi liberado`,
+  notifSessionWarnTitle: 'Claude — Aviso de Limite de Sessão',
+  notifSessionWarnBody: (pct, threshold) => `Uso da sessão em ${pct}% (limite de ${threshold}% atingido)`,
+  notifWeeklyWarnTitle: 'Claude — Aviso de Limite Semanal',
+  notifWeeklyWarnBody: (pct, threshold) => `Uso semanal em ${pct}% (limite de ${threshold}% atingido)`,
+  trayInitialTooltip: 'Claude Usage Monitor',
+  trayTooltipLine1: (sessionPct, weeklyPct) => `Claude Usage — Sessão: ${sessionPct}% | Semanal: ${weeklyPct}%`,
+  trayTooltipLine2: (sessionResets, weeklyResets) => `Sessão reinicia em: ${sessionResets} | Semana reinicia em: ${weeklyResets}`,
+  trayRefreshNow: 'Atualizar Agora',
+  trayLaunchAtStartup: 'Iniciar com o sistema',
+  trayExit: 'Sair',
+};
+
+export function getMainTranslations(lang?: string): MainTranslations {
+  if (lang === 'pt-BR') return ptBR;
+  return en;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { pollingService } from './services/pollingService';
 import { getSettings, saveSettings } from './services/settingsService';
 import { setLaunchAtStartup, isLaunchAtStartupEnabled } from './services/startupService';
 import { checkAndNotify, syncWindowState, sendTestNotification } from './services/notificationService';
+import { getMainTranslations } from './i18n/mainTranslations';
 import { UsageData } from './models/usageData';
 
 // Required for Windows notifications
@@ -120,26 +121,28 @@ function formatTimeUntil(isoDate: string): string {
 
 function updateTrayTooltip(data: UsageData): void {
   if (!tray) return;
-  const sessionPct     = Math.round(data.five_hour.utilization);
-  const weeklyPct      = Math.round(data.seven_day.utilization);
-  const sessionResets  = formatTimeUntil(data.five_hour.resets_at);
-  const weeklyResets   = formatTimeUntil(data.seven_day.resets_at);
+  const t = getMainTranslations(getSettings().language);
+  const sessionPct    = Math.round(data.five_hour.utilization).toString();
+  const weeklyPct     = Math.round(data.seven_day.utilization).toString();
+  const sessionResets = formatTimeUntil(data.five_hour.resets_at);
+  const weeklyResets  = formatTimeUntil(data.seven_day.resets_at);
   tray.setToolTip(
-    `Claude Usage — Session: ${sessionPct}% | Weekly: ${weeklyPct}%\n` +
-    `Session resets in: ${sessionResets} | Weekly resets in: ${weeklyResets}`
+    t.trayTooltipLine1(sessionPct, weeklyPct) + '\n' +
+    t.trayTooltipLine2(sessionResets, weeklyResets)
   );
 }
 
 function buildContextMenu(): Menu {
   const settings = getSettings();
+  const t = getMainTranslations(settings.language);
   return Menu.buildFromTemplate([
     {
-      label: 'Refresh Now',
+      label: t.trayRefreshNow,
       click: () => void pollingService.triggerNow(),
     },
     { type: 'separator' },
     {
-      label: 'Launch at Startup',
+      label: t.trayLaunchAtStartup,
       type: 'checkbox',
       checked: settings.launchAtStartup,
       click: (menuItem) => {
@@ -152,7 +155,7 @@ function buildContextMenu(): Menu {
     },
     { type: 'separator' },
     {
-      label: 'Exit',
+      label: t.trayExit,
       click: () => app.quit(),
     },
   ]);
@@ -166,7 +169,7 @@ function createTray(): Tray {
     : nativeImage.createFromPath(iconPath);
 
   const t = new Tray(icon);
-  t.setToolTip('Claude Usage Monitor');
+  t.setToolTip(getMainTranslations(getSettings().language).trayInitialTooltip);
   t.setContextMenu(buildContextMenu());
 
   t.on('click', () => togglePopup());

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,6 +1,7 @@
 import { Notification, shell } from 'electron';
 import { UsageData } from '../models/usageData';
 import { getSettings } from './settingsService';
+import { getMainTranslations } from '../i18n/mainTranslations';
 import * as path from 'path';
 
 interface NotificationState {
@@ -34,11 +35,8 @@ export function syncWindowState(data: UsageData): void {
 
 export function sendTestNotification(): void {
   const settings = getSettings();
-  showToast(
-    'Claude — Test Notification',
-    'Notifications are working correctly',
-    settings.notifications.soundEnabled
-  );
+  const t = getMainTranslations(settings.language);
+  showToast(t.notifTestTitle, t.notifTestBody, settings.notifications.soundEnabled);
 }
 
 function isSignificantReset(prevAt: string, newAt: string, minGapMs: number): boolean {
@@ -57,13 +55,14 @@ export function checkAndNotify(data: UsageData): void {
     notifyOnWindowReset, soundEnabled,
   } = settings.notifications;
 
+  const t = getMainTranslations(settings.language);
   const sessionPct = Math.round(data.five_hour.utilization);
   const weeklyPct  = Math.round(data.seven_day.utilization);
 
   // Detect time-window reset (resets_at changed to a new value)
   if (prevSessionResetsAt !== null && isSignificantReset(prevSessionResetsAt, data.five_hour.resets_at, 60 * 60 * 1000)) {
     if (notifyOnWindowReset) {
-      showToast('Claude — Session Window Reset', 'Your 5-hour usage window has reset', soundEnabled);
+      showToast(t.notifSessionWindowResetTitle, t.notifSessionWindowResetBody, soundEnabled);
     }
     state.sessionNotified = false;
   }
@@ -71,7 +70,7 @@ export function checkAndNotify(data: UsageData): void {
 
   if (prevWeeklyResetsAt !== null && isSignificantReset(prevWeeklyResetsAt, data.seven_day.resets_at, 24 * 60 * 60 * 1000)) {
     if (notifyOnWindowReset) {
-      showToast('Claude — Weekly Window Reset', 'Your weekly usage window has reset', soundEnabled);
+      showToast(t.notifWeeklyWindowResetTitle, t.notifWeeklyWindowResetBody, soundEnabled);
     }
     state.weeklyNotified = false;
   }
@@ -80,11 +79,7 @@ export function checkAndNotify(data: UsageData): void {
   // Session: detect drop below resetThreshold after having been notified
   if (sessionPct < resetThreshold) {
     if (state.sessionNotified && notifyOnReset) {
-      showToast(
-        'Claude — Session Limit Freed',
-        `Session usage dropped to ${sessionPct}% — limit has reset`,
-        soundEnabled
-      );
+      showToast(t.notifSessionFreedTitle, t.notifSessionFreedBody(sessionPct), soundEnabled);
     }
     state.sessionNotified = false;
   }
@@ -92,32 +87,20 @@ export function checkAndNotify(data: UsageData): void {
   // Weekly: detect drop below resetThreshold after having been notified
   if (weeklyPct < resetThreshold) {
     if (state.weeklyNotified && notifyOnReset) {
-      showToast(
-        'Claude — Weekly Limit Freed',
-        `Weekly usage dropped to ${weeklyPct}% — limit has reset`,
-        soundEnabled
-      );
+      showToast(t.notifWeeklyFreedTitle, t.notifWeeklyFreedBody(weeklyPct), soundEnabled);
     }
     state.weeklyNotified = false;
   }
 
   // Session threshold crossed (warn)
   if (!state.sessionNotified && sessionPct >= sessionThreshold) {
-    showToast(
-      'Claude — Session Limit Warning',
-      `Session usage is at ${sessionPct}% (${sessionThreshold}% threshold reached)`,
-      soundEnabled
-    );
+    showToast(t.notifSessionWarnTitle, t.notifSessionWarnBody(sessionPct, sessionThreshold), soundEnabled);
     state.sessionNotified = true;
   }
 
   // Weekly threshold crossed (warn)
   if (!state.weeklyNotified && weeklyPct >= weeklyThreshold) {
-    showToast(
-      'Claude — Weekly Limit Warning',
-      `Weekly usage is at ${weeklyPct}% (${weeklyThreshold}% threshold reached)`,
-      soundEnabled
-    );
+    showToast(t.notifWeeklyWarnTitle, t.notifWeeklyWarnBody(weeklyPct, weeklyThreshold), soundEnabled);
     state.weeklyNotified = true;
   }
 }


### PR DESCRIPTION
## Summary
- Created `src/i18n/mainTranslations.ts` with en/pt-BR strings for all main-process user-facing text
- Updated `notificationService.ts` to read `getSettings().language` and use translated notification titles/bodies
- Updated `main.ts` tray tooltip and context menu to use translated strings

## Root Cause
The i18n system existed only in the renderer. The main process hardcoded all strings in English, never consulting the `language` setting stored in `settingsService`.

## Related
Closes #9

## Test plan
- [ ] `npm run build` exits cleanly
- [ ] Set language to Português (BR) → trigger test notification → notification appears in Portuguese
- [ ] Tray context menu shows "Atualizar Agora", "Iniciar com o sistema", "Sair" in pt-BR
- [ ] Tray tooltip shows "Sessão:" / "Semanal:" labels in pt-BR
- [ ] Switch back to English → all strings revert to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)