### PR TITLE
fix: preserve window position on data refresh when alwaysVisible is active

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,8 +82,10 @@ function togglePopup(): void {
   if (popup.isVisible()) {
     popup.hide();
   } else {
-    userMovedPopup = false;
-    positionPopup();
+    if (!getSettings().alwaysVisible) {
+      userMovedPopup = false;
+      positionPopup();
+    }
     popup.show();
     popup.focus();
 
@@ -233,7 +235,9 @@ function registerIpcHandlers(): void {
       popup.setBounds({ x, y: Math.max(workArea.y, clampedY), width: POPUP_WIDTH, height: h }, false);
     } else {
       popup.setSize(POPUP_WIDTH, h, false);
-      positionPopup();
+      if (!getSettings().alwaysVisible || !popup.isVisible()) {
+        positionPopup();
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- In `togglePopup()`, skip `positionPopup()` when `alwaysVisible` is on — re-opening the popup from the tray no longer resets the user's custom position
- In `set-window-height` handler, skip `positionPopup()` when `alwaysVisible` is on and popup is already visible — data refreshes no longer snap the window back to tray position

## Root Cause
`togglePopup()` unconditionally reset `userMovedPopup = false` on every show. After any hide+show cycle, the flag was cleared, causing the next data refresh to call `positionPopup()` and snap the window to tray position.

## Related
Closes #11

## Test plan
- [ ] `npm run build` exits cleanly
- [ ] `alwaysVisible` OFF: popup still snaps to tray on open (no regression)
- [ ] `alwaysVisible` ON: drag popup to custom position, wait for refresh — window stays put
- [ ] `alwaysVisible` ON: click tray icon to hide/show — window returns to custom position, not tray

🤖 Generated with [Claude Code](https://claude.com/claude-code)