### PR TITLE
feat: modal de confirmação para forçar refresh com rate limit ativo

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -204,6 +204,11 @@ function registerIpcHandlers(): void {
     await pollingService.triggerNow();
   });
 
+  ipcMain.handle('force-refresh-now', async () => {
+    suppressNextNotification = true;
+    await pollingService.forceNow();
+  });
+
   ipcMain.on('tray-icon-data', (_event, dataUrl: string) => {
     if (!tray || !dataUrl) return;
     try {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -31,6 +31,10 @@ contextBridge.exposeInMainWorld('claudeUsage', {
     return ipcRenderer.invoke('refresh-now');
   },
 
+  forceRefreshNow: (): Promise<void> => {
+    return ipcRenderer.invoke('force-refresh-now');
+  },
+
   sendTrayIcon: (dataUrl: string): void => {
     ipcRenderer.send('tray-icon-data', dataUrl);
   },

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -45,6 +45,7 @@ declare global {
       saveSettings: (s: Partial<AppSettings>) => Promise<void>;
       setStartup: (v: boolean) => Promise<void>;
       refreshNow: () => Promise<void>;
+      forceRefreshNow: () => Promise<void>;
       testNotification: () => Promise<void>;
       sendTrayIcon: (dataUrl: string) => void;
       closeWindow: () => void;
@@ -234,6 +235,7 @@ function applyAutoRefresh(enabled: boolean, intervalSeconds: number): void {
 // ── Rate limit countdown ──────────────────────────────────────────────────────
 
 let countdownTimer: ReturnType<typeof setInterval> | null = null;
+let isRateLimited = false;
 
 function startRateLimitCountdown(until: number, resetAt?: number): void {
   if (countdownTimer) clearInterval(countdownTimer);
@@ -253,6 +255,7 @@ function startRateLimitCountdown(until: number, resetAt?: number): void {
     if (remaining <= 0) {
       timer.textContent = tr().rateLimitNow;
       if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
+      isRateLimited = false;
       return;
     }
     const m = Math.floor(remaining / 60000);
@@ -532,6 +535,12 @@ function applyTheme(theme: AppSettings['theme']): void {
   }
 }
 
+// ── Force refresh modal ───────────────────────────────────────────────────────
+
+function showForceRefreshModal(): void {
+  document.getElementById('force-refresh-modal')!.classList.remove('hidden');
+}
+
 // ── Init ──────────────────────────────────────────────────────────────────────
 
 function init(): void {
@@ -543,6 +552,7 @@ function init(): void {
   window.claudeUsage.onUsageUpdated((data) => updateUI(data));
 
   window.claudeUsage.onRateLimited((until, resetAt) => {
+    isRateLimited = true;
     startRateLimitCountdown(until, resetAt);
   });
 
@@ -566,7 +576,21 @@ function init(): void {
   });
 
   document.getElementById('btn-refresh')!.addEventListener('click', () => {
+    if (isRateLimited) {
+      showForceRefreshModal();
+      return;
+    }
     void window.claudeUsage.refreshNow();
+    (document.getElementById('updated-text') as HTMLElement).textContent = tr().refreshingText;
+  });
+
+  document.getElementById('modal-cancel')!.addEventListener('click', () => {
+    document.getElementById('force-refresh-modal')!.classList.add('hidden');
+  });
+
+  document.getElementById('modal-confirm')!.addEventListener('click', () => {
+    document.getElementById('force-refresh-modal')!.classList.add('hidden');
+    void window.claudeUsage.forceRefreshNow();
     (document.getElementById('updated-text') as HTMLElement).textContent = tr().refreshingText;
   });
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -195,6 +195,16 @@
   <!-- Hidden canvas for tray icon rendering -->
   <canvas id="tray-canvas" width="32" height="32"></canvas>
 
+  <div id="force-refresh-modal" class="modal-overlay hidden">
+    <div class="modal-box">
+      <p class="modal-msg">Rate limit ativo. Forçar atualização mesmo assim?</p>
+      <div class="modal-actions">
+        <button id="modal-cancel">Cancelar</button>
+        <button id="modal-confirm">Forçar</button>
+      </div>
+    </div>
+  </div>
+
   <script src="app.js"></script>
 </body>
 </html>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -522,3 +522,72 @@ body {
 #tray-canvas {
   display: none;
 }
+
+/* ── Force-refresh modal ───────────────────────────────────────────── */
+.modal-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-overlay.hidden {
+  display: none;
+}
+
+.modal-box {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px 14px;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  width: 240px;
+}
+
+.modal-msg {
+  font-size: 12px;
+  color: var(--text-primary);
+  margin-bottom: 14px;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.modal-actions button {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 16px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+#modal-cancel {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+#modal-cancel:hover {
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+#modal-confirm {
+  background: var(--accent-blue);
+  color: #ffffff;
+  border: 1px solid transparent;
+}
+
+#modal-confirm:hover {
+  background: rgba(59, 130, 246, 0.8);
+}

--- a/src/services/pollingService.ts
+++ b/src/services/pollingService.ts
@@ -57,6 +57,14 @@ export class PollingService extends EventEmitter {
     await this.poll();
   }
 
+  async forceNow(): Promise<void> {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    await this.poll();
+  }
+
   private isIdle(): boolean {
     try {
       return powerMonitor.getSystemIdleTime() >= IDLE_THRESHOLD;


### PR DESCRIPTION
## Summary
- Clicar em **Atualizar** com rate limit ativo agora exibe um modal de confirmação
- Botão **Cancelar** fecha o modal sem fazer nada
- Botão **Forçar** chama `pollingService.forceNow()` que bypassa a checagem de rate limit e dispara a requisição imediatamente

## Related
Closes #13

## Test plan
- [ ] `npm run build` sai limpo
- [ ] Sem rate limit ativo: botão Atualizar funciona normalmente (sem modal)
- [ ] Com rate limit ativo: clicar Atualizar abre o modal
- [ ] Cancelar no modal: fecha sem fazer requisição
- [ ] Forçar no modal: dispara requisição, fecha modal, atualiza texto de status

🤖 Generated with [Claude Code](https://claude.com/claude-code)