### PR TITLE
feat: verificar e notificar atualizações disponíveis no GitHub

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, screen, powerMonitor } from 'electron';
+import { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, screen, powerMonitor, shell, Notification } from 'electron';
 import * as path from 'path';
 import { pollingService } from './services/pollingService';
 import { getSettings, saveSettings } from './services/settingsService';
@@ -6,6 +6,7 @@ import { setLaunchAtStartup, isLaunchAtStartupEnabled } from './services/startup
 import { checkAndNotify, syncWindowState, sendTestNotification } from './services/notificationService';
 import { getMainTranslations } from './i18n/mainTranslations';
 import { UsageData } from './models/usageData';
+import { checkForUpdate } from './services/updateService';
 
 // Prevent multiple instances (also allows NSIS installer to detect running process)
 const gotTheLock = app.requestSingleInstanceLock();
@@ -140,6 +141,40 @@ function updateTrayTooltip(data: UsageData): void {
   );
 }
 
+// ─── Update check ────────────────────────────────────────────────────────────
+
+async function runUpdateCheck(forceCheck = false): Promise<void> {
+  const settings = getSettings();
+  const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+  if (!forceCheck && Date.now() - settings.lastUpdateCheck < TWENTY_FOUR_HOURS) {
+    return;
+  }
+  try {
+    const result = await checkForUpdate(app.getVersion());
+    saveSettings({ lastUpdateCheck: Date.now() });
+    if (result.hasUpdate) {
+      showUpdateAvailableToast(result.latestVersion, result.releaseUrl);
+      if (popup) {
+        popup.webContents.send('update-available', { version: result.latestVersion, url: result.releaseUrl });
+      }
+    }
+  } catch {
+    // silent failure
+  }
+}
+
+function showUpdateAvailableToast(version: string, url: string): void {
+  if (!Notification.isSupported()) return;
+  const notif = new Notification({
+    title: 'Claude Usage Monitor',
+    body: `v${version} is available. Click to download.`,
+  });
+  notif.on('click', () => {
+    void shell.openExternal(url);
+  });
+  notif.show();
+}
+
 function buildContextMenu(): Menu {
   const settings = getSettings();
   const t = getMainTranslations(settings.language);
@@ -147,6 +182,10 @@ function buildContextMenu(): Menu {
     {
       label: t.trayRefreshNow,
       click: () => void pollingService.triggerNow(),
+    },
+    {
+      label: 'Check for Updates',
+      click: () => void runUpdateCheck(true),
     },
     { type: 'separator' },
     {
@@ -235,6 +274,10 @@ function registerIpcHandlers(): void {
     popup?.hide();
   });
 
+  ipcMain.on('open-release-url', (_e, url: string) => {
+    void shell.openExternal(url);
+  });
+
   ipcMain.on('set-window-height', (_event, height: number) => {
     if (!popup) return;
     const workArea = screen.getPrimaryDisplay().workArea;
@@ -314,6 +357,10 @@ app.whenReady().then(() => {
   });
 
   pollingService.start();
+
+  setTimeout(() => {
+    void runUpdateCheck();
+  }, 5000);
 });
 
 app.on('window-all-closed', () => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -50,4 +50,12 @@ contextBridge.exposeInMainWorld('claudeUsage', {
   setWindowHeight: (height: number): void => {
     ipcRenderer.send('set-window-height', height);
   },
+
+  onUpdateAvailable: (cb: (info: { version: string; url: string }) => void): void => {
+    ipcRenderer.on('update-available', (_event, info: { version: string; url: string }) => cb(info));
+  },
+
+  openReleaseUrl: (url: string): void => {
+    ipcRenderer.send('open-release-url', url);
+  },
 });

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -50,6 +50,8 @@ declare global {
       sendTrayIcon: (dataUrl: string) => void;
       closeWindow: () => void;
       setWindowHeight: (h: number) => void;
+      onUpdateAvailable: (cb: (info: { version: string; url: string }) => void) => void;
+      openReleaseUrl: (url: string) => void;
     };
   }
 }
@@ -569,6 +571,22 @@ function init(): void {
 
     (document.getElementById('updated-text') as HTMLElement).textContent =
       tr().failedAt(new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
+  });
+
+  window.claudeUsage.onUpdateAvailable(({ version, url }) => {
+    const banner = document.getElementById('update-banner') as HTMLElement;
+    const label  = document.getElementById('update-version-label') as HTMLElement;
+    if (banner && label) {
+      label.textContent = `v${version} available`;
+      banner.style.display = 'flex';
+      banner.dataset.url = url;
+      fitWindow();
+    }
+  });
+
+  document.getElementById('btn-update-download')!.addEventListener('click', () => {
+    const url = (document.getElementById('update-banner') as HTMLElement)?.dataset.url;
+    if (url) window.claudeUsage.openReleaseUrl(url);
   });
 
   document.getElementById('btn-close')!.addEventListener('click', () => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -36,6 +36,15 @@
       </div>
     </div>
 
+    <!-- Update available banner -->
+    <div class="update-banner" id="update-banner" style="display:none">
+      <span class="update-icon">&#8593;</span>
+      <div class="update-text">
+        <span id="update-version-label">Update available</span>
+      </div>
+      <button id="btn-update-download">Download</button>
+    </div>
+
     <!-- Gauges -->
     <div class="gauges-grid">
       <div class="gauge-card">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -353,6 +353,47 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/* ── Update banner ─────────────────────────────────────────────────── */
+.update-banner {
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: var(--radius-sm);
+  padding: 7px 10px;
+  margin-bottom: 10px;
+  display: none;
+  align-items: center;
+  gap: 8px;
+}
+
+.update-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+  color: var(--accent-blue);
+}
+
+.update-text {
+  flex: 1;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+#btn-update-download {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent-blue);
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+#btn-update-download:hover {
+  background: rgba(59, 130, 246, 0.28);
+}
+
 /* ── Scrollbar ─────────────────────────────────────────────────────── */
 .content::-webkit-scrollbar {
   width: 4px;

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -23,6 +23,8 @@ export interface AppSettings {
   rateLimitedUntil: number;    // unix ms — 0 means not rate limited
   rateLimitCount: number;      // consecutive 429s for backoff
   rateLimitResetAt: number;    // API-provided reset timestamp (unix ms), 0 if absent
+  lastUpdateCheck: number;     // unix ms timestamp of last update check, 0 if never
+  skippedVersion: string;      // version tag the user chose to skip
 }
 
 const defaults: AppSettings = {
@@ -46,6 +48,8 @@ const defaults: AppSettings = {
   rateLimitedUntil: 0,
   rateLimitCount: 0,
   rateLimitResetAt: 0,
+  lastUpdateCheck: 0,
+  skippedVersion: '',
 };
 
 const store = new Store<AppSettings>({
@@ -75,6 +79,8 @@ const store = new Store<AppSettings>({
     rateLimitedUntil: { type: 'number' },
     rateLimitCount: { type: 'number' },
     rateLimitResetAt: { type: 'number' },
+    lastUpdateCheck: { type: 'number' },
+    skippedVersion: { type: 'string' },
   },
 });
 
@@ -92,6 +98,8 @@ export function getSettings(): AppSettings {
     rateLimitedUntil: store.get('rateLimitedUntil', defaults.rateLimitedUntil),
     rateLimitCount: store.get('rateLimitCount', defaults.rateLimitCount),
     rateLimitResetAt: store.get('rateLimitResetAt', defaults.rateLimitResetAt),
+    lastUpdateCheck: store.get('lastUpdateCheck', defaults.lastUpdateCheck),
+    skippedVersion: store.get('skippedVersion', defaults.skippedVersion),
   };
 }
 
@@ -131,5 +139,11 @@ export function saveSettings(settings: Partial<AppSettings>): void {
   }
   if (settings.rateLimitResetAt !== undefined) {
     store.set('rateLimitResetAt', settings.rateLimitResetAt);
+  }
+  if (settings.lastUpdateCheck !== undefined) {
+    store.set('lastUpdateCheck', settings.lastUpdateCheck);
+  }
+  if (settings.skippedVersion !== undefined) {
+    store.set('skippedVersion', settings.skippedVersion);
   }
 }

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -1,0 +1,62 @@
+import * as https from 'https';
+
+export interface UpdateCheckResult {
+  hasUpdate: boolean;
+  latestVersion: string;
+  releaseUrl: string;
+}
+
+function isNewer(latest: string, current: string): boolean {
+  const parse = (v: string) => v.replace(/^v/, '').split('.').map(Number);
+  const [lMaj, lMin, lPatch] = parse(latest);
+  const [cMaj, cMin, cPatch] = parse(current);
+  if (lMaj !== cMaj) return lMaj > cMaj;
+  if (lMin !== cMin) return lMin > cMin;
+  return lPatch > cPatch;
+}
+
+export function checkForUpdate(currentVersion: string): Promise<UpdateCheckResult> {
+  return new Promise((resolve) => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    const options = {
+      hostname: 'api.github.com',
+      path: '/repos/edilsonvilarinho/claude-usage-monitor/releases/latest',
+      method: 'GET',
+      headers: {
+        'User-Agent': `claude-usage-monitor/${currentVersion}`,
+        'Accept': 'application/vnd.github+json',
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+      res.on('end', () => {
+        clearTimeout(timeout);
+        try {
+          const json = JSON.parse(body) as { tag_name?: string; html_url?: string };
+          const latestVersion = json.tag_name ?? '';
+          const releaseUrl = json.html_url ?? '';
+          const hasUpdate = latestVersion !== '' && isNewer(latestVersion, currentVersion);
+          resolve({ hasUpdate, latestVersion: latestVersion.replace(/^v/, ''), releaseUrl });
+        } catch {
+          resolve({ hasUpdate: false, latestVersion: '', releaseUrl: '' });
+        }
+      });
+    });
+
+    req.on('error', () => {
+      clearTimeout(timeout);
+      resolve({ hasUpdate: false, latestVersion: '', releaseUrl: '' });
+    });
+
+    controller.signal.addEventListener('abort', () => {
+      req.destroy();
+      resolve({ hasUpdate: false, latestVersion: '', releaseUrl: '' });
+    });
+
+    req.end();
+  });
+}


### PR DESCRIPTION
## Summary
- Adiciona `updateService.ts` que consulta a GitHub Releases API e compara versões via semver manual (sem dependências extras)
- Toast nativo do Windows notifica o usuário quando há update — clicar abre a release page no browser
- Banner azul no popup exibe a versão disponível com botão "Download"
- Item "Check for Updates" no menu do tray permite verificação manual (ignora throttle de 24h)
- Falhas de rede são silenciosas e não afetam a experiência principal

## Related
Closes #15

## Test plan
- [ ] `npm run build` sai com exit 0
- [ ] Toast nativo aparece quando há versão mais nova no GitHub (5s após startup)
- [ ] Banner `#update-banner` exibe versão e botão "Download" no popup
- [ ] Botão "Download" abre browser na release page do GitHub
- [ ] Clique no toast do Windows abre browser na release page
- [ ] Segunda inicialização dentro de 24h não dispara nova verificação
- [ ] "Check for Updates" no menu tray força verificação imediata
- [ ] Sem internet: nenhum crash, nenhuma mensagem de erro visível
- [ ] Timeout de 10s respeitado sem travar o app

🤖 Generated with [Claude Code](https://claude.com/claude-code)