### PR TITLE
feat: modal de aviso quando credenciais do Claude não foram criadas

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,8 @@ let lastUsageData: UsageData | null = null;
 let suppressNextNotification = false;
 let userMovedPopup = false;
 let currentRateLimitUntil = 0; // restored from disk on startup
+let credentialMissing = false;
+let credentialPath = '';
 
 const POPUP_WIDTH  = 340;
 const POPUP_HEIGHT = 210;
@@ -48,6 +50,13 @@ function createPopup(): BrowserWindow {
   });
 
   win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+
+  // Re-send any pending state once renderer is ready (handles early IPC timing)
+  win.webContents.once('did-finish-load', () => {
+    if (credentialMissing) {
+      win.webContents.send('credential-missing', credentialPath);
+    }
+  });
 
   win.on('blur', () => {
     if (popup && popup.isVisible() && !getSettings().alwaysVisible) {
@@ -104,6 +113,10 @@ function togglePopup(): void {
     if (currentRateLimitUntil > Date.now()) {
       const { rateLimitResetAt } = getSettings();
       popup.webContents.send('rate-limited', currentRateLimitUntil, rateLimitResetAt || undefined);
+    }
+    // Re-surface credential error if still unresolved
+    if (credentialMissing) {
+      popup.webContents.send('credential-missing', credentialPath);
     }
   }
 }
@@ -319,6 +332,7 @@ app.whenReady().then(() => {
   // Start polling and wire up events
   pollingService.on('usage-updated', (data: UsageData) => {
     lastUsageData = data;
+    credentialMissing = false;
     if (currentRateLimitUntil > 0) {
       currentRateLimitUntil = 0;
       saveSettings({ rateLimitedUntil: 0, rateLimitCount: 0 });
@@ -329,10 +343,6 @@ app.whenReady().then(() => {
       suppressNextNotification = false;
     } else {
       checkAndNotify(data);
-    }
-
-    if (popup?.isVisible()) {
-      popup.webContents.send('usage-updated', data);
     }
 
     // Always update tray icon via renderer (even when hidden)
@@ -351,6 +361,28 @@ app.whenReady().then(() => {
   });
 
   pollingService.on('error', (err: Error) => {
+    const isCredError = err.message.includes('credentials not found') ||
+                        err.message.includes('Invalid credentials file');
+    if (isCredError) {
+      credentialMissing = true;
+      // Extract path from error message or fall back to default
+      const match = err.message.match(/Expected location: (.+)/);
+      credentialPath = match
+        ? match[1].trim()
+        : path.join(process.env['USERPROFILE'] || '~', '.claude', '.credentials.json');
+      if (popup) {
+        if (!popup.isVisible()) {
+          if (!getSettings().alwaysVisible) {
+            userMovedPopup = false;
+            positionPopup();
+          }
+          popup.show();
+          popup.focus();
+        }
+        popup.webContents.send('credential-missing', credentialPath);
+      }
+      return; // do not send usage-error for credential errors
+    }
     if (popup?.isVisible()) {
       popup.webContents.send('usage-error', err.message);
     }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -58,4 +58,8 @@ contextBridge.exposeInMainWorld('claudeUsage', {
   openReleaseUrl: (url: string): void => {
     ipcRenderer.send('open-release-url', url);
   },
+
+  onCredentialMissing: (cb: (credPath: string) => void): void => {
+    ipcRenderer.on('credential-missing', (_e, credPath: string) => cb(credPath));
+  },
 });

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -52,6 +52,7 @@ declare global {
       setWindowHeight: (h: number) => void;
       onUpdateAvailable: (cb: (info: { version: string; url: string }) => void) => void;
       openReleaseUrl: (url: string) => void;
+      onCredentialMissing: (cb: (credPath: string) => void) => void;
     };
   }
 }
@@ -551,7 +552,10 @@ function init(): void {
 
   void loadSettings();
 
-  window.claudeUsage.onUsageUpdated((data) => updateUI(data));
+  window.claudeUsage.onUsageUpdated((data) => {
+    (document.getElementById('credential-modal') as HTMLElement).classList.add('hidden');
+    updateUI(data);
+  });
 
   window.claudeUsage.onRateLimited((until, resetAt) => {
     isRateLimited = true;
@@ -571,6 +575,15 @@ function init(): void {
 
     (document.getElementById('updated-text') as HTMLElement).textContent =
       tr().failedAt(new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
+  });
+
+  window.claudeUsage.onCredentialMissing((credPath: string) => {
+    (document.getElementById('credential-path-value') as HTMLElement).textContent = credPath;
+    (document.getElementById('credential-modal') as HTMLElement).classList.remove('hidden');
+  });
+
+  document.getElementById('credential-retry-btn')?.addEventListener('click', async () => {
+    await window.claudeUsage.refreshNow();
   });
 
   window.claudeUsage.onUpdateAvailable(({ version, url }) => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -214,6 +214,30 @@
     </div>
   </div>
 
+  <div id="credential-modal" class="modal-overlay hidden">
+    <div class="modal-box credential-modal-box">
+      <div class="credential-modal-icon">&#9888;</div>
+      <h3 class="credential-modal-title">Credenciais não encontradas</h3>
+      <p class="credential-modal-desc">
+        Faça login no Claude Code para que o monitor possa acessar seus dados de uso.
+      </p>
+      <ol class="credential-steps">
+        <li>Instale o Claude Code:<br>
+          <code>winget install Anthropic.Claude</code>
+        </li>
+        <li>Abra um terminal e execute:<br>
+          <code>claude</code>
+        </li>
+        <li>Siga o fluxo de login no navegador</li>
+      </ol>
+      <p class="credential-path-label">Arquivo esperado:</p>
+      <code class="credential-path" id="credential-path-value"></code>
+      <div class="modal-actions">
+        <button id="credential-retry-btn">Tentar novamente</button>
+      </div>
+    </div>
+  </div>
+
   <script src="app.js"></script>
 </body>
 </html>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -632,3 +632,84 @@ body {
 #modal-confirm:hover {
   background: rgba(59, 130, 246, 0.8);
 }
+
+/* ── Credential missing modal ──────────────────────────────────────── */
+.credential-modal-box {
+  width: 280px;
+  text-align: left;
+}
+
+.credential-modal-icon {
+  font-size: 28px;
+  color: var(--accent-yellow);
+  text-align: center;
+  margin-bottom: 6px;
+}
+
+.credential-modal-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 8px 0;
+  text-align: center;
+}
+
+.credential-modal-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin: 0 0 10px 0;
+  line-height: 1.4;
+}
+
+.credential-steps {
+  font-size: 11px;
+  color: var(--text-primary);
+  padding-left: 16px;
+  margin: 0 0 10px 0;
+  line-height: 1.6;
+}
+
+.credential-steps li {
+  margin-bottom: 6px;
+}
+
+.credential-steps code {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-size: 10px;
+  font-family: monospace;
+  color: var(--text-primary);
+  margin-top: 2px;
+}
+
+.credential-path-label {
+  font-size: 10px;
+  color: var(--text-secondary);
+  margin: 0 0 2px 0;
+}
+
+.credential-path {
+  display: block;
+  font-size: 9px;
+  color: var(--text-secondary);
+  word-break: break-all;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 3px 5px;
+  margin-bottom: 10px;
+  font-family: monospace;
+}
+
+#credential-retry-btn {
+  background: var(--accent-blue);
+  color: #ffffff;
+  border: 1px solid transparent;
+}
+
+#credential-retry-btn:hover {
+  background: rgba(59, 130, 246, 0.8);
+}


### PR DESCRIPTION
## Summary
- Modal informativo aparece automaticamente (popup abre) quando `~/.claude/.credentials.json` não existe ou é inválido
- Exibe passo a passo: instalar Claude Code (`winget install Anthropic.Claude`) e executar `claude` para login
- Mostra o caminho esperado do arquivo de credenciais
- Botão "Tentar novamente" aciona refresh — modal fecha ao receber dados com sucesso
- Reaparece ao abrir popup manualmente enquanto credenciais ainda ausentes
- Fix de timing: `did-finish-load` garante que o IPC não seja perdido na inicialização do app
- Erros de credencial não exibem o banner genérico (modal já cobre)

## Related
Closes #17

## Test plan
- [ ] `npm run build` exits cleanly
- [ ] Com `~/.claude/.credentials.json` ausente: popup abre automaticamente com modal ao iniciar
- [ ] Modal exibe caminho correto do arquivo esperado
- [ ] `#error-banner` NÃO aparece simultaneamente ao modal
- [ ] Botão "Tentar novamente" com credenciais ainda ausentes → modal reaparece
- [ ] Restaurar credenciais + "Tentar novamente" → modal fecha, dados carregam
- [ ] Abrir popup manualmente com credenciais ausentes → modal aparece
- [ ] Com credenciais válidas → modal nunca aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)