### PR TITLE
fix: stop repositioning popup on data updates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -302,7 +302,7 @@ function registerIpcHandlers(): void {
       popup.setBounds({ x, y: Math.max(workArea.y, clampedY), width: POPUP_WIDTH, height: h }, false);
     } else {
       popup.setSize(POPUP_WIDTH, h, false);
-      if (!getSettings().alwaysVisible || !popup.isVisible()) {
+      if (!popup.isVisible()) {
         positionPopup();
       }
     }


### PR DESCRIPTION
## Summary
- O popup se movia para cima do ícone da bandeja toda vez que dados eram atualizados (polling ou botão Refresh)
- A causa era `!getSettings().alwaysVisible` na condição do handler `set-window-height`, sempre verdadeiro no modo padrão
- Fix: simplificado para `!popup.isVisible()` — `positionPopup()` só roda quando a janela não está visível

## Root Cause
```typescript
// ANTES (bug): repositionava sempre que alwaysVisible=false (modo padrão)
if (!getSettings().alwaysVisible || !popup.isVisible()) {

// DEPOIS (fix): só posiciona quando janela ainda não está visível
if (!popup.isVisible()) {
```

## Related
Closes #19

## Test plan
- [ ] `npm run build` exits cleanly ✅
- [ ] Abrir popup → aguardar polling → janela NÃO se move
- [ ] Abrir popup → clicar Refresh → janela NÃO se move
- [ ] Fechar e reabrir popup → posicionado corretamente acima da bandeja
- [ ] Mover janela manualmente → atualizar dados → posição preservada

🤖 Generated with [Claude Code](https://claude.com/claude-code)