### PR TITLE
feat: gerar ZIPs dos executáveis no release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ npm run dev          # compile main + start Electron (system tray)
 npm run build        # compile main TS + bundle renderer
 npm run dist         # NSIS installer + portable EXE → dist-build/
 npm run dist:portable
+npm run dist:zip     # zip installer + portable → dist-build/
+npm run release      # dist + dist:portable + zip → dist-build/
 npx tsc -p tsconfig.main.json   # main only
 node build-renderer.js           # renderer only
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -p tsconfig.main.json && node build-renderer.js",
     "dist": "npm run build && electron-builder --win",
     "dist:portable": "npm run build && electron-builder --win portable",
+    "dist:zip": "node scripts/zip-release.js",
+    "release": "npm run dist && npm run dist:portable && node scripts/zip-release.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/scripts/zip-release.js
+++ b/scripts/zip-release.js
@@ -1,0 +1,39 @@
+// @ts-check
+'use strict';
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+const version = pkg.version;
+const productName = pkg.build.productName;
+const outDir = path.join(__dirname, '..', 'dist-build');
+
+const files = [
+  {
+    exe: path.join(outDir, `${productName} Setup ${version}.exe`),
+    zip: path.join(outDir, `Claude-Usage-Monitor-Setup-${version}.zip`),
+    label: 'installer',
+  },
+  {
+    exe: path.join(outDir, `${productName} ${version}.exe`),
+    zip: path.join(outDir, `Claude-Usage-Monitor-Portable-${version}.zip`),
+    label: 'portable',
+  },
+];
+
+for (const { exe, zip, label } of files) {
+  if (!fs.existsSync(exe)) {
+    console.error(`ERROR: ${label} EXE not found: ${exe}`);
+    process.exit(1);
+  }
+  if (fs.existsSync(zip)) {
+    fs.unlinkSync(zip);
+  }
+  execSync(
+    `powershell -NoProfile -Command "Compress-Archive -Path '${exe}' -DestinationPath '${zip}'"`,
+    { stdio: 'inherit' }
+  );
+  console.log(`Created ${label} ZIP: ${path.basename(zip)}`);
+}


### PR DESCRIPTION
## Summary
- Cria `scripts/zip-release.js` que gera ZIPs do installer e portable via PowerShell, sem dependências novas
- Adiciona `npm run dist:zip` e `npm run release` no `package.json`
- Documenta novos scripts no `CLAUDE.md`

## Related
Closes #21

## Test plan
- [ ] `npm run build` sai limpo
- [ ] `npm run dist && npm run dist:portable && npm run dist:zip` gera `Claude-Usage-Monitor-Setup-x.x.x.zip` e `Claude-Usage-Monitor-Portable-x.x.x.zip` em `dist-build/`
- [ ] `npm run release` executa tudo em sequência

🤖 Generated with [Claude Code](https://claude.com/claude-code)