### PR TITLE
hotfix: disable asar to fix tray icon crash on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       ],
       "icon": "assets/icon.ico"
     },
-    "asar": true,
+    "asar": false,
     "compression": "maximum",
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## Hotfix
O app não abria após instalação. Com `asar: true`, o `assets/` é empacotado dentro de `app.asar`. A API `nativeImage.createFromPath()` usa código nativo que bypassa o virtual filesystem do Electron, retornando uma imagem vazia. `new Tray(emptyImage)` lança exceção no Windows, crashando o app no `app.whenReady()` antes de qualquer janela aparecer.

**Fix:** `"asar": true` → `"asar": false` em `package.json`.

## Root Cause
`nativeImage.createFromPath` não suporta caminhos dentro de arquivos `.asar` (usa camada nativa, não o Node.js patchado pelo Electron).

## Risk Assessment
- Minimal change: yes (1 linha)
- Regression risk: low — reverte para comportamento que funcionava antes de `672b452`

## Related
Closes #23

## Test plan
- [x] `npm run build` sai limpo
- [ ] `npm run dist` gera instalador
- [ ] Instalar e confirmar ícone na system tray

🤖 Generated with [Claude Code](https://claude.com/claude-code)