### PR TITLE
hotfix: disable runAfterFinish to fix 'Atalho Não Encontrado' on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": false,
-      "runAfterFinish": true
+      "runAfterFinish": false
     }
   }
 }


### PR DESCRIPTION
## Hotfix
O instalador mostrava 'Atalho Não Encontrado' ao finalizar com o checkbox 'Executar o Claude Usage Monitor' marcado. O `runAfterFinish: true` faz o NSIS tentar abrir o app via `.lnk` shortcut logo após a extração, mas o Windows não consegue resolver o caminho nesse momento.

**Fix:** `runAfterFinish: false` — o usuário abre manualmente pelo Start Menu após instalar.

## Risk Assessment
- Minimal change: yes (1 linha)
- Regression risk: low — apenas remove o auto-launch pós-instalação

## Related
Closes #25

## Test plan
- [x] `npm run build` sai limpo
- [ ] Instalar e confirmar que não aparece mais o erro 'Atalho Não Encontrado'
- [ ] App abre normalmente pelo Start Menu após instalação

🤖 Generated with [Claude Code](https://claude.com/claude-code)