### PR TITLE
hotfix: set electron-builder output to dist-build to stop installer bloat

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
       ],
       "icon": "assets/icon.ico"
     },
+    "directories": {
+      "output": "dist-build"
+    },
     "asar": false,
     "compression": "maximum",
     "nsis": {


### PR DESCRIPTION
## Hotfix
O instalador pedia 4.6 GB e não instalava o app corretamente — só o desinstalador aparecia em `C:\Program Files\Claude Usage Monitor`.

**Causa raiz:** `electron-builder` gravava os instaladores em `dist/`. O campo `files: ["dist/**/*"]` incluía todos os `.exe` de builds anteriores no próximo build — crescimento exponencial: 153 MB → 459 MB → 1.4 GB → 4.6 GB.

**Fix:** `"directories": { "output": "dist-build" }` no build config. O `zip-release.js` já usava `dist-build/` — agora o electron-builder também usa.

## Risk Assessment
- Minimal change: yes (3 linhas)
- Regression risk: low — apenas muda onde os artefatos são gravados

## Related
Closes #27

## Test plan
- [x] `npm run build` sai limpo
- [ ] `npm run dist` gera instalador em `dist-build/` (não em `dist/`)
- [ ] Instalador tem tamanho razoável (~30 MB)
- [ ] App instala e abre normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)