### PR TITLE
feat: add next-poll countdown timer to footer

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -105,6 +105,7 @@ const translations = {
     failedAt:   (time: string) => `Failed: ${time}`,
     resetsIn:   (d: number, h: number, m: number) =>
       d > 0 ? `Resets in ${d}d ${h}h` : h > 0 ? `Resets in ${h}h ${m}m` : `Resets in ${m}m`,
+    nextPollIn: (t: string) => `Next update in ${t}`,
   },
   'pt-BR': {
     sessionLabel:     'Sessão (5h)',
@@ -149,6 +150,7 @@ const translations = {
     failedAt:   (time: string) => `Falhou: ${time}`,
     resetsIn:   (d: number, h: number, m: number) =>
       d > 0 ? `Reinicia em ${d}d ${h}h` : h > 0 ? `Reinicia em ${h}h ${m}m` : `Reinicia em ${m}m`,
+    nextPollIn: (t: string) => `Próxima atualização em ${t}`,
   },
 } as const;
 
@@ -219,20 +221,56 @@ function applySize(size: AppSettings['windowSize']): void {
 // ── Auto-refresh ──────────────────────────────────────────────────────────────
 
 let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+let currentAutoRefreshIntervalMs = 300 * 1000;
 
 function applyAutoRefresh(enabled: boolean, intervalSeconds: number): void {
+  stopNextPollCountdown();
   if (autoRefreshTimer !== null) {
     clearInterval(autoRefreshTimer);
     autoRefreshTimer = null;
   }
   if (enabled) {
     const ms = Math.max(60, intervalSeconds) * 1000;
+    currentAutoRefreshIntervalMs = ms;
     autoRefreshTimer = setInterval(() => {
       void window.claudeUsage.refreshNow();
     }, ms);
+    startNextPollCountdown(ms);
   }
   const intervalRow = document.getElementById('row-auto-refresh-interval') as HTMLElement;
   intervalRow.style.opacity = enabled ? '1' : '0.4';
+}
+
+// ── Next poll countdown ───────────────────────────────────────────────────────
+
+let nextPollTimer: ReturnType<typeof setInterval> | null = null;
+let nextPollAt = 0;
+
+function startNextPollCountdown(intervalMs: number): void {
+  stopNextPollCountdown();
+  nextPollAt = Date.now() + intervalMs;
+  const el = document.getElementById('next-poll-text') as HTMLElement;
+  if (!el) return;
+
+  function tick(): void {
+    const remaining = nextPollAt - Date.now();
+    if (remaining <= 0) {
+      el.textContent = '';
+      return;
+    }
+    const m = Math.floor(remaining / 60000);
+    const s = Math.floor((remaining % 60000) / 1000);
+    el.textContent = tr().nextPollIn(`${m}:${String(s).padStart(2, '0')}`);
+  }
+
+  tick();
+  nextPollTimer = setInterval(tick, 1000);
+}
+
+function stopNextPollCountdown(): void {
+  if (nextPollTimer) { clearInterval(nextPollTimer); nextPollTimer = null; }
+  const el = document.getElementById('next-poll-text') as HTMLElement;
+  if (el) el.textContent = '';
 }
 
 // ── Rate limit countdown ──────────────────────────────────────────────────────
@@ -241,6 +279,7 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null;
 let isRateLimited = false;
 
 function startRateLimitCountdown(until: number, resetAt?: number): void {
+  stopNextPollCountdown();
   if (countdownTimer) clearInterval(countdownTimer);
 
   const banner = document.getElementById('rate-limit-banner') as HTMLElement;
@@ -450,6 +489,10 @@ function updateUI(data: UsageData): void {
   updateTrayIcon(sessionPct, weeklyPct);
 
   fitWindow();
+
+  if (autoRefreshTimer !== null) {
+    startNextPollCountdown(currentAutoRefreshIntervalMs);
+  }
 }
 
 // ── Settings ──────────────────────────────────────────────────────────────────

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -86,6 +86,7 @@
     <!-- Updated / refresh footer -->
     <div class="footer">
       <span class="updated-text" id="updated-text">Loading...</span>
+      <span class="next-poll-text" id="next-poll-text"></span>
       <button class="refresh-btn" id="btn-refresh" data-i18n="refreshText">↺ Refresh</button>
     </div>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -279,6 +279,12 @@ body {
   color: var(--text-secondary);
 }
 
+.next-poll-text {
+  font-size: 10px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
 .refresh-btn {
   font-size: 10px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Adds a "Próxima atualização em M:SS" countdown in the popup footer
- Visible only when auto-refresh is enabled
- Resets on every successful poll (`usage-updated`)
- Stops when rate-limited (rate-limit banner takes over), resumes após próximo poll bem-sucedido
- Nenhuma mudança no main process ou IPC — inteiramente no renderer

## Related
Closes #29

## Test plan
- [ ] `npm run build` exits cleanly ✅
- [ ] Countdown aparece no footer quando autoRefresh está ON
- [ ] Countdown some quando autoRefresh está OFF
- [ ] Countdown reinicia ao intervalo completo após cada refresh de dados
- [ ] Countdown some quando rate limit banner é exibido
- [ ] Countdown retorna após rate limit resolver (próximo poll bem-sucedido)
- [ ] Mudar intervalo enquanto rodando reinicia o countdown com novo valor
- [ ] Reabrir popup mostra o tempo restante correto

🤖 Generated with [Claude Code](https://claude.com/claude-code)