### PR TITLE
fix: reposition popup after resize when data updates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -302,9 +302,7 @@ function registerIpcHandlers(): void {
       popup.setBounds({ x, y: Math.max(workArea.y, clampedY), width: POPUP_WIDTH, height: h }, false);
     } else {
       popup.setSize(POPUP_WIDTH, h, false);
-      if (!popup.isVisible()) {
-        positionPopup();
-      }
+      positionPopup();
     }
   });
 }


### PR DESCRIPTION
## Summary
- Popup estava mudando de posição toda vez que os dados atualizavam com o popup aberto
- Causa raiz: `positionPopup()` estava guardada por `!popup.isVisible()` no handler `set-window-height`, então nunca rodava com a janela visível
- Fix: remover o guard para que `positionPopup()` seja sempre chamada quando `userMovedPopup == false`

## Root Cause
`setSize` mudava a altura da janela mas a posição `y` (calculada com a altura antiga na abertura) nunca era corrigida — a janela crescia para baixo sem se reposicionar acima do ícone do tray.

## Related
Closes #31

## Test plan
- [ ] `npm run build` sai limpo ✅
- [ ] Abrir popup, aguardar refresh dos dados — popup permanece ancorado acima do tray icon
- [ ] Mover popup manualmente, aguardar refresh — posição permanece onde o usuário colocou (caminho `userMovedPopup == true` inalterado)
- [ ] Modo `alwaysVisible`: popup atualiza sem reposicionar

🤖 Generated with [Claude Code](https://claude.com/claude-code)