### PR TITLE
fix: use atomic setBounds for resize+reposition to eliminate popup jump

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -71,15 +71,15 @@ function createPopup(): BrowserWindow {
   return win;
 }
 
-function positionPopup(): void {
+function positionPopup(height?: number): void {
   if (!tray || !popup) return;
 
-  const [, currentHeight] = popup.getSize();
+  const h = height ?? popup.getSize()[1];
   const trayBounds = tray.getBounds();
   const workArea = screen.getPrimaryDisplay().workArea;
 
   let x = Math.round(trayBounds.x + trayBounds.width / 2 - POPUP_WIDTH / 2);
-  let y = Math.round(trayBounds.y - currentHeight - 8);
+  let y = Math.round(trayBounds.y - h - 8);
 
   // Clamp horizontally
   x = Math.max(workArea.x, Math.min(x, workArea.x + workArea.width - POPUP_WIDTH));
@@ -89,7 +89,11 @@ function positionPopup(): void {
     y = trayBounds.y + trayBounds.height + 8;
   }
 
-  popup.setPosition(x, y, false);
+  if (height !== undefined) {
+    popup.setBounds({ x, y, width: POPUP_WIDTH, height: h }, false);
+  } else {
+    popup.setPosition(x, y, false);
+  }
 }
 
 function togglePopup(): void {
@@ -301,8 +305,7 @@ function registerIpcHandlers(): void {
       const clampedY = Math.min(y, workArea.y + workArea.height - h);
       popup.setBounds({ x, y: Math.max(workArea.y, clampedY), width: POPUP_WIDTH, height: h }, false);
     } else {
-      popup.setSize(POPUP_WIDTH, h, false);
-      positionPopup();
+      positionPopup(h);
     }
   });
 }


### PR DESCRIPTION
## Summary
- Popup continuava pulsando/saltando de posição a cada atualização de dados, mesmo após #32
- Causa raiz: `setSize` + `positionPopup()` eram chamadas separadas, deixando um frame visual com tamanho novo mas posição velha
- Fix: `positionPopup(height?)` agora usa `setBounds` atômico quando altura é fornecida, aplicando resize + reposition em uma única chamada

## Root Cause
```typescript
// Antes — duas chamadas separadas causavam flash visual
popup.setSize(POPUP_WIDTH, h, false);   // frame: tamanho novo, posição velha
positionPopup();                         // frame: posição corrigida

// Depois — operação atômica
positionPopup(h);  // setBounds({ x, y, width, height }) — sem frames intermediários
```

## Related
Closes #33

## Test plan
- [ ] `npm run build` exits cleanly ✅
- [ ] Abrir popup e aguardar refresh — popup não pula de posição
- [ ] Mover popup manualmente e aguardar refresh — posição respeitada (`userMovedPopup == true` inalterado)
- [ ] `togglePopup()` sem argumento continua usando `setPosition` (sem regressão)
- [ ] Modo `alwaysVisible` inalterado

🤖 Generated with [Claude Code](https://claude.com/claude-code)