### PR TITLE
feat: show installed version in tray tooltip and popup footer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,8 @@ function updateTrayTooltip(data: UsageData): void {
   const weeklyResets  = formatTimeUntil(data.seven_day.resets_at);
   tray.setToolTip(
     t.trayTooltipLine1(sessionPct, weeklyPct) + '\n' +
-    t.trayTooltipLine2(sessionResets, weeklyResets)
+    t.trayTooltipLine2(sessionResets, weeklyResets) + '\n' +
+    `v${app.getVersion()}`
   );
 }
 
@@ -233,7 +234,7 @@ function createTray(): Tray {
     : nativeImage.createFromPath(iconPath);
 
   const t = new Tray(icon);
-  t.setToolTip(getMainTranslations(getSettings().language).trayInitialTooltip);
+  t.setToolTip(`${getMainTranslations(getSettings().language).trayInitialTooltip} v${app.getVersion()}`);
   t.setContextMenu(buildContextMenu());
 
   t.on('click', () => togglePopup());
@@ -245,6 +246,8 @@ function createTray(): Tray {
 
 function registerIpcHandlers(): void {
   ipcMain.handle('get-settings', () => getSettings());
+
+  ipcMain.handle('get-app-version', () => app.getVersion());
 
   ipcMain.handle('save-settings', (_event, settings) => {
     saveSettings(settings);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -62,4 +62,6 @@ contextBridge.exposeInMainWorld('claudeUsage', {
   onCredentialMissing: (cb: (credPath: string) => void): void => {
     ipcRenderer.on('credential-missing', (_e, credPath: string) => cb(credPath));
   },
+
+  getAppVersion: (): Promise<string> => ipcRenderer.invoke('get-app-version'),
 });

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -53,6 +53,7 @@ declare global {
       onUpdateAvailable: (cb: (info: { version: string; url: string }) => void) => void;
       openReleaseUrl: (url: string) => void;
       onCredentialMissing: (cb: (credPath: string) => void) => void;
+      getAppVersion: () => Promise<string>;
     };
   }
 }
@@ -594,6 +595,11 @@ function init(): void {
   weeklyChart  = createGauge('gauge-weekly');
 
   void loadSettings();
+
+  void window.claudeUsage.getAppVersion().then((version) => {
+    const el = document.getElementById('app-version');
+    if (el) el.textContent = `v${version}`;
+  });
 
   window.claudeUsage.onUsageUpdated((data) => {
     (document.getElementById('credential-modal') as HTMLElement).classList.add('hidden');

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -87,6 +87,7 @@
     <div class="footer">
       <span class="updated-text" id="updated-text">Loading...</span>
       <span class="next-poll-text" id="next-poll-text"></span>
+      <span class="app-version" id="app-version"></span>
       <button class="refresh-btn" id="btn-refresh" data-i18n="refreshText">↺ Refresh</button>
     </div>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -285,6 +285,12 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+.app-version {
+  font-size: 10px;
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
 .refresh-btn {
   font-size: 10px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Tray tooltip agora exibe a versão como 3ª linha (ex: `v2.1.6`), inclusive no tooltip inicial antes dos dados carregarem
- Footer do popup exibe a versão instalada de forma discreta

## Related
Closes #35

## Test plan
- [ ] `npm run build` sai sem erros
- [ ] Tooltip do tray mostra `v2.1.6` na 3ª linha após dados carregarem
- [ ] Tooltip inicial (antes de dados) também mostra a versão
- [ ] Footer do popup exibe `v2.1.6` em texto sutil (10px, opacidade 0.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)