### PR TITLE
feat: exibir countdown de próxima atualização na tooltip do tray

### DIFF
--- a/src/i18n/mainTranslations.ts
+++ b/src/i18n/mainTranslations.ts
@@ -17,6 +17,7 @@ export interface MainTranslations {
   trayTooltipLine1: (sessionPct: string, weeklyPct: string) => string;
   trayTooltipLine2: (sessionResets: string, weeklyResets: string) => string;
   trayTooltipLine3: (sessionAt: string, weeklyAt: string) => string;
+  trayTooltipNextUpdate: (time: string) => string;
   trayRefreshNow: string;
   trayLaunchAtStartup: string;
   trayExit: string;
@@ -41,6 +42,7 @@ const en: MainTranslations = {
   trayTooltipLine1: (sessionPct, weeklyPct) => `Claude Usage — Session: ${sessionPct}% | Weekly: ${weeklyPct}%`,
   trayTooltipLine2: (sessionResets, weeklyResets) => `Session resets in: ${sessionResets} | Weekly resets in: ${weeklyResets}`,
   trayTooltipLine3: (sessionAt, weeklyAt) => `Session at: ${sessionAt} | Weekly at: ${weeklyAt}`,
+  trayTooltipNextUpdate: (t) => `Next update in: ${t}`,
   trayRefreshNow: 'Refresh Now',
   trayLaunchAtStartup: 'Launch at Startup',
   trayExit: 'Exit',
@@ -65,6 +67,7 @@ const ptBR: MainTranslations = {
   trayTooltipLine1: (sessionPct, weeklyPct) => `Claude Usage — Sessão: ${sessionPct}% | Semanal: ${weeklyPct}%`,
   trayTooltipLine2: (sessionResets, weeklyResets) => `Sessão reinicia em: ${sessionResets} | Semana reinicia em: ${weeklyResets}`,
   trayTooltipLine3: (sessionAt, weeklyAt) => `Sessão às: ${sessionAt} | Semanal às: ${weeklyAt}`,
+  trayTooltipNextUpdate: (t) => `Próxima atualização em: ${t}`,
   trayRefreshNow: 'Atualizar Agora',
   trayLaunchAtStartup: 'Iniciar com o sistema',
   trayExit: 'Sair',

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ app.setAppUserModelId('com.claudeusage.monitor');
 let tray: Tray | null = null;
 let popup: BrowserWindow | null = null;
 let lastUsageData: UsageData | null = null;
+let tooltipRefreshTimer: NodeJS.Timeout | null = null;
 let suppressNextNotification = false;
 let positionedByUser = false;
 let savedPopupPosition: { x: number; y: number } | null = null;
@@ -202,6 +203,16 @@ function formatResetAt(isoDate: string, locale: string): string {
   return tz ? `${timeStr} • ${tz}` : timeStr;
 }
 
+function formatNextPoll(nextPollAt: number): string {
+  const remaining = nextPollAt - Date.now();
+  if (remaining <= 0) return '…';
+  const totalSec = Math.ceil(remaining / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min === 0) return `${sec}s`;
+  return `${min}m ${String(sec).padStart(2, '0')}s`;
+}
+
 function updateTrayTooltip(data: UsageData): void {
   if (!tray) return;
   const t = getMainTranslations(getSettings().language);
@@ -212,10 +223,13 @@ function updateTrayTooltip(data: UsageData): void {
   const locale        = getSettings().language === 'pt-BR' ? 'pt-BR' : 'en';
   const sessionAt     = formatResetAt(data.five_hour.resets_at, locale);
   const weeklyAt      = formatResetAt(data.seven_day.resets_at, locale);
+  const npAt = pollingService.nextPollAt;
+  const nextLine = npAt > 0 ? t.trayTooltipNextUpdate(formatNextPoll(npAt)) : '';
   tray.setToolTip(
     t.trayTooltipLine1(sessionPct, weeklyPct) + '\n' +
     t.trayTooltipLine2(sessionResets, weeklyResets) + '\n' +
     t.trayTooltipLine3(sessionAt, weeklyAt) + '\n' +
+    (nextLine ? nextLine + '\n' : '') +
     `v${app.getVersion()}`
   );
 }
@@ -404,6 +418,10 @@ app.whenReady().then(() => {
       saveSettings({ rateLimitedUntil: 0, rateLimitCount: 0 });
     }
     updateTrayTooltip(data);
+    if (tooltipRefreshTimer) clearInterval(tooltipRefreshTimer);
+    tooltipRefreshTimer = setInterval(() => {
+      if (lastUsageData) updateTrayTooltip(lastUsageData);
+    }, 30_000);
     if (suppressNextNotification) {
       syncWindowState(data);
       suppressNextNotification = false;
@@ -477,4 +495,5 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   pollingService.stop();
+  if (tooltipRefreshTimer) { clearInterval(tooltipRefreshTimer); tooltipRefreshTimer = null; }
 });

--- a/src/services/pollingService.ts
+++ b/src/services/pollingService.ts
@@ -22,6 +22,9 @@ export class PollingService extends EventEmitter {
   private rateLimitCount = 0; // consecutive 429s — drives exponential backoff
   private fastCyclesLeft = 0;
   private running = false;
+  private _nextPollAt = 0;
+
+  get nextPollAt(): number { return this._nextPollAt; }
 
   restoreRateLimit(until: number, count = 1): void {
     if (until > Date.now()) {
@@ -98,6 +101,7 @@ export class PollingService extends EventEmitter {
     // Respect rate limit before making any request
     if (this.rateLimited && this.rateLimitedUntil > Date.now()) {
       const delay = this.nextInterval();
+      this._nextPollAt = Date.now() + delay;
       this.timer = setTimeout(() => void this.poll(), delay);
       return;
     }
@@ -163,6 +167,7 @@ export class PollingService extends EventEmitter {
     if (!this.running) return;
 
     const delay = this.nextInterval();
+    this._nextPollAt = Date.now() + delay;
     this.timer = setTimeout(() => void this.poll(), delay);
   }
 }


### PR DESCRIPTION
## Summary
- Adiciona linha "Próxima atualização em: Xm Xs" na tooltip do tray
- Timer interno de 30s atualiza o countdown automaticamente sem novo dado da API
- Suporte aos dois idiomas (EN e PT-BR)

## Related
Closes #43

## Test plan
- [ ] `npm run build` exits cleanly
- [ ] Hover no tray → tooltip exibe 4ª linha com countdown
- [ ] Aguardar 30s → valor decrementou
- [ ] Trocar idioma para EN → "Next update in: Xm Xs"
- [ ] Fechar app via Exit → sem travamento (timer limpo em `before-quit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)