### PR TITLE
feat: suporte Linux (#45)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ function createPopup(): BrowserWindow {
     alwaysOnTop: true,
     resizable: false,
     show: false,
-    backgroundMaterial: 'acrylic',
+    ...(process.platform === 'win32' ? { backgroundMaterial: 'acrylic' as const } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -453,7 +453,7 @@ app.whenReady().then(() => {
       const match = err.message.match(/Expected location: (.+)/);
       credentialPath = match
         ? match[1].trim()
-        : path.join(process.env['USERPROFILE'] || '~', '.claude', '.credentials.json');
+        : path.join(process.env['USERPROFILE'] || process.env['HOME'] || '~', '.claude', '.credentials.json');
       if (popup) {
         if (!popup.isVisible()) {
           if (!getSettings().alwaysVisible) {

--- a/src/services/credentialService.ts
+++ b/src/services/credentialService.ts
@@ -10,34 +10,36 @@ const OAUTH_REFRESH_PATH = '/v1/oauth/token';
 function findCredentialPaths(): string[] {
   const candidates: string[] = [];
 
-  // Primary: Windows native path
-  const winPath = path.join(process.env['USERPROFILE'] || process.env['HOME'] || '', '.claude', '.credentials.json');
-  if (fs.existsSync(winPath)) {
-    candidates.push(winPath);
+  // Primary: native path (~/.claude/.credentials.json)
+  const homePath = path.join(process.env['USERPROFILE'] || process.env['HOME'] || '', '.claude', '.credentials.json');
+  if (fs.existsSync(homePath)) {
+    candidates.push(homePath);
   }
 
-  // Fallback: WSL paths
-  const wslBase = '\\\\wsl.localhost';
-  if (fs.existsSync(wslBase)) {
-    try {
-      const distros = fs.readdirSync(wslBase);
-      for (const distro of distros) {
-        const homeBase = path.join(wslBase, distro, 'home');
-        if (!fs.existsSync(homeBase)) continue;
-        try {
-          const users = fs.readdirSync(homeBase);
-          for (const user of users) {
-            const wslCredPath = path.join(homeBase, user, '.claude', '.credentials.json');
-            if (fs.existsSync(wslCredPath)) {
-              candidates.push(wslCredPath);
+  // Fallback: WSL paths (Windows only)
+  if (process.platform === 'win32') {
+    const wslBase = '\\\\wsl.localhost';
+    if (fs.existsSync(wslBase)) {
+      try {
+        const distros = fs.readdirSync(wslBase);
+        for (const distro of distros) {
+          const homeBase = path.join(wslBase, distro, 'home');
+          if (!fs.existsSync(homeBase)) continue;
+          try {
+            const users = fs.readdirSync(homeBase);
+            for (const user of users) {
+              const wslCredPath = path.join(homeBase, user, '.claude', '.credentials.json');
+              if (fs.existsSync(wslCredPath)) {
+                candidates.push(wslCredPath);
+              }
             }
+          } catch {
+            // skip inaccessible directories
           }
-        } catch {
-          // skip inaccessible directories
         }
+      } catch {
+        // WSL not available or inaccessible
       }
-    } catch {
-      // WSL not available or inaccessible
     }
   }
 
@@ -140,7 +142,7 @@ export async function getAccessToken(): Promise<string> {
   if (!filePath) {
     throw new Error(
       'Claude credentials not found. Make sure you are logged in to Claude Code.\n' +
-      'Expected location: ' + path.join(process.env['USERPROFILE'] || '~', '.claude', '.credentials.json')
+      'Expected location: ' + path.join(process.env['USERPROFILE'] || process.env['HOME'] || '~', '.claude', '.credentials.json')
     );
   }
 


### PR DESCRIPTION
## Resumo

- `main.ts`: `backgroundMaterial: 'acrylic'` aplicado condicionalmente (`process.platform === 'win32'`) — corrige tray que não aparecia no Linux
- `credentialService.ts`: path principal usa `USERPROFILE || HOME`; busca WSL restrita ao Windows
- `main.ts`: fallback do path de credencial ausente usa `HOME` no Linux

Closes #45

## Test plan
- [ ] Testar tray aparecendo no Linux após instalação do `.deb`
- [ ] Verificar que comportamento no Windows permanece idêntico (acrylic, WSL fallback)
- [ ] Confirmar que mensagem de credencial ausente exibe path correto em ambas as plataformas

🤖 Generated with [Claude Code](https://claude.com/claude-code)