### PR TITLE
feat: analytics de uso — curva diária, burn rate, horário do pico e resumo

### DIFF
--- a/BUSINESS_RULES.md
+++ b/BUSINESS_RULES.md
@@ -195,9 +195,11 @@ estTime    = newest.ts + hoursLeft * 3_600_000
 
 Exibição: `↑ X.X%/h · esgota ~HH:MM` (pt-BR) ou `↑ X.X%/h · exhausts ~HH:MM` (en), na linha abaixo do gauge de sessão.
 
-### Popup de Curva Diária
+### Modal de Histórico Diário (Curva de Consumo)
 
-Ao clicar em uma coluna do gráfico Ciclo Semanal, abre um popup flutuante inline (`#day-curve-popup`) com um mini gráfico de linha da série temporal do dia clicado. Clicar novamente na mesma coluna fecha o popup (toggle). Fechado automaticamente ao esconder a janela (`visibilitychange`).
+Ao clicar em uma coluna do gráfico Ciclo Semanal, abre o modal `#day-detail-modal` (`openDayDetailModal(date)`) com o gráfico de linha completo da série temporal do dia clicado — exibe Sessão (5h) e Semanal (7d) ao longo das horas. Fechado com o botão X (`#day-detail-close`) ou ao esconder a janela (`visibilitychange`).
+
+> **Regra:** o clique em `.daily-col` DEVE chamar `openDayDetailModal`. Não substituir por popup inline — o modal completo é a única visualização de curva diária.
 
 ### Resumo Analítico (Painel de Janelas)
 

--- a/BUSINESS_RULES.md
+++ b/BUSINESS_RULES.md
@@ -156,9 +156,58 @@ interface DailySnapshot {
 
 **`sessionAccum`:** Soma apenas janelas *completadas*. A janela em curso é excluída para evitar dupla contagem — ela já está refletida no `maxSession`. Ao computar métricas de "uso total do dia", o cálculo correto é `sessionAccum + maxSession`.
 
+### Campo `peakTs` — rastreamento temporal do pico
+
+`SessionWindowRecord` e `CurrentSessionWindow` possuem o campo opcional `peakTs?: number` (unix ms) que registra o instante exato em que o pico de utilização foi observado.
+
+**Regras de rastreamento:**
+- **Primeiro poll da janela** (`!currentWindow`): `peakTs = now`
+- **Mesma janela, novo valor maior** (`sessionPctInt > currentWindow.peak`): `peakTs = now`
+- **Mesma janela, valor menor ou igual** (pico não mudou): `peakTs` preservado
+- **Após reset** (nova janela): `peakTs = undefined` — nova janela ainda não tem pico registrado
+- **Ao completar a janela** (`completedWindow`): herda `peakTs` da `currentWindow`
+
+**Por que opcional?** Compatibilidade com janelas históricas persistidas antes da introdução do campo. `peakTs === undefined` é tratado graciosamente na UI (exibe `—` ou omite).
+
+**Passo `now`:** `updateDailySnapshot` aceita `now: number = Date.now()` como parâmetro, permitindo injeção nos testes.
+
 **Retenção:** O `dailyHistory` mantém no máximo 8 dias. Entradas além desse limite são removidas das mais antigas. Isso garante que a série temporal não cresça indefinidamente no electron-store local.
 
 **Fronteira de meia-noite:** Se uma janela de 5h começa num dia e termina no seguinte (ex.: começou às 22h, resetou às 03h), o pico é atribuído ao dia em que a janela *começou*, não ao dia do reset. O campo `currentWindow.date` armazena o dia de início para esse caso.
+
+### Burn Rate e Previsão de Esgotamento
+
+Calculado no renderer (`updateBurnRate()`) após cada `onUsageUpdated`. Usa os últimos 3 pontos da série temporal do dia corrente.
+
+**Fórmula:**
+```
+burnRate   = (newest.session - oldest.session) / deltaHours   [%/h]
+hoursLeft  = (100 - currentSession) / burnRate
+estTime    = newest.ts + hoursLeft * 3_600_000
+```
+
+**Condições de supressão** (resultado ocultado):
+- Menos de 2 pontos na série do dia
+- Sessão atual < 5% (sem uso relevante)
+- `deltaHours <= 0` (pontos no mesmo instante)
+- `burnRate <= 0` (uso decrescendo)
+- `hoursLeft > 6` (muito longe para ser útil)
+
+Exibição: `↑ X.X%/h · esgota ~HH:MM` (pt-BR) ou `↑ X.X%/h · exhausts ~HH:MM` (en), na linha abaixo do gauge de sessão.
+
+### Popup de Curva Diária
+
+Ao clicar em uma coluna do gráfico Ciclo Semanal, abre um popup flutuante inline (`#day-curve-popup`) com um mini gráfico de linha da série temporal do dia clicado. Clicar novamente na mesma coluna fecha o popup (toggle). Fechado automaticamente ao esconder a janela (`visibilitychange`).
+
+### Resumo Analítico (Painel de Janelas)
+
+Exibido no final do modal de Relatório de Uso (`#report-analytics`), calculado sobre as janelas recentes mais a janela corrente:
+
+| Métrica | Cálculo |
+|---------|---------|
+| Janelas/dia | Média de janelas por dia único no histórico de janelas |
+| Pico comum | Hora do dia com maior frequência de `peakTs` (bucket de 1h) |
+| Dias >80% | Streak contínuo de dias com `maxSession >= 80` (do mais recente para o mais antigo) |
 
 ---
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -811,7 +811,7 @@ app.whenReady().then(() => {
 
     // ── Snapshot diário + session window tracking ───────────────────────────────
     const { dailyHistory: updatedDailyHistory, currentWindow, completedWindow } =
-      updateDailySnapshot(accountData.dailyHistory ?? [], today, data, accountData.currentSessionWindow);
+      updateDailySnapshot(accountData.dailyHistory ?? [], today, data, accountData.currentSessionWindow, now);
 
     const updatedSessionWindows = [...(accountData.sessionWindows ?? [])];
     if (completedWindow) {

--- a/src/models/usageData.ts
+++ b/src/models/usageData.ts
@@ -17,6 +17,7 @@ export interface SessionWindowRecord {
   resetsAt: string; // ISO datetime — quando esta janela resetou
   peak: number;     // pico de utilization observado (inteiro, pode ser > 100)
   date: string;     // YYYY-MM-DD — dia ao qual esta janela pertence
+  peakTs?: number;  // unix ms — quando o pico foi observado
 }
 
 /** Estado da janela de sessão corrente — persistido para detectar resets após restart */
@@ -24,6 +25,7 @@ export interface CurrentSessionWindow {
   resetsAt: string; // five_hour.resets_at atual da API
   peak: number;     // maior utilization visto nesta janela até agora
   date?: string;    // YYYY-MM-DD — dia em que esta janela começou
+  peakTs?: number;  // unix ms — quando o pico foi observado
 }
 
 export interface DailySnapshot {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1184,7 +1184,7 @@ function renderDailyChart(dailyData: DailySnapshot[], weeklyResetsAt: string, li
   container.querySelectorAll<HTMLElement>('.daily-col:not(.future)[data-date]').forEach(col => {
     col.addEventListener('click', () => {
       const date = col.dataset.date;
-      if (date) void openDayCurvePopup(date, col);
+      if (date) void openDayDetailModal(date);
     });
   });
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -75,8 +75,8 @@ declare global {
       onNextPollAt: (cb: (nextPollAt: number) => void) => void;
       onLastResponse: (cb: (info: { ok: boolean; code?: number; message?: string; time: number }) => void) => void;
       getDayTimeSeries: (date: string) => Promise<{ ts: number; session: number; weekly: number; credits?: number }[]>;
-      getSessionWindows: () => Promise<{ resetsAt: string; peak: number; date: string }[]>;
-      getCurrentSessionWindow: () => Promise<{ resetsAt: string; peak: number } | null>;
+      getSessionWindows: () => Promise<{ resetsAt: string; peak: number; date: string; peakTs?: number }[]>;
+      getCurrentSessionWindow: () => Promise<{ resetsAt: string; peak: number; peakTs?: number } | null>;
       getSettings: () => Promise<AppSettings>;
       saveSettings: (s: Partial<AppSettings>) => Promise<void>;
       setStartup: (v: boolean) => Promise<void>;
@@ -730,6 +730,8 @@ let lastSessionPct: number | null = null;
 let currentDailyHistory: DailySnapshot[] = [];
 let dayDetailChart: Chart | null = null;
 let reportChart: Chart | null = null;
+let dayCurveChart: Chart | null = null;
+let dayCurveOpenDate: string | null = null;
 
 async function openReportModal(): Promise<void> {
   const modal = document.getElementById('report-modal')!;
@@ -852,7 +854,7 @@ async function openReportModal(): Promise<void> {
   const isPtBR = currentLang === 'pt-BR';
   const fmt = (d: Date) => d.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' });
 
-  const buildRow = (resetsAt: string, peak: number, index: number, isOpen: boolean) => {
+  const buildRow = (resetsAt: string, peak: number, index: number, isOpen: boolean, peakTs?: number) => {
     const endDt   = new Date(resetsAt);
     const startDt = new Date(endDt.getTime() - 5 * 60 * 60 * 1000);
     const fmtDate = (d: Date) => d.toLocaleDateString(locale, { day: 'numeric', month: 'short' });
@@ -866,21 +868,64 @@ async function openReportModal(): Promise<void> {
     const badge = isOpen
       ? `<span class="window-badge open">${isPtBR ? 'Aberta' : 'Open'}</span>`
       : `<span class="window-badge closed">${isPtBR ? 'Fechada' : 'Closed'}</span>`;
+    const peakTimeStr = peakTs
+      ? new Date(peakTs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      : null;
+    const peakTimeHtml = peakTimeStr
+      ? `<span class="window-peak-time">${isPtBR ? 'pico' : 'peak at'} ${peakTimeStr}</span>`
+      : '';
     return `<div class="report-window-row">
       <span class="report-window-label">${label} ${badge}</span>
       <span class="report-window-date">${rangeStr}</span>
-      <span class="report-window-peak" style="color:${color}">${pct}%</span>
+      <span class="report-window-peak" style="color:${color}">${pct}%${peakTimeHtml}</span>
     </div>`;
   };
 
   let windowRows = '';
   let idx = 1;
   if (currentWindow) {
-    windowRows += buildRow(currentWindow.resetsAt, currentWindow.peak, idx++, true);
+    windowRows += buildRow(currentWindow.resetsAt, currentWindow.peak, idx++, true, currentWindow.peakTs);
   }
-  windowRows += recentWindows.map(w => buildRow(w.resetsAt, w.peak, idx++, false)).join('');
+  windowRows += recentWindows.map(w => buildRow(w.resetsAt, w.peak, idx++, false, w.peakTs)).join('');
 
   windowsEl.innerHTML = `<div class="report-windows-title">${windowsTitle}</div>` + windowRows;
+
+  // Resumo analítico
+  const analyticsEl = document.getElementById('report-analytics');
+  if (analyticsEl) {
+    const today = new Date().toLocaleDateString('sv');
+    const allW = [...recentWindows] as { resetsAt: string; peak: number; date: string; peakTs?: number }[];
+    if (currentWindow) allW.push({ resetsAt: currentWindow.resetsAt, peak: currentWindow.peak, date: today, peakTs: currentWindow.peakTs });
+
+    const byDate = new Map<string, number>();
+    allW.forEach(w => byDate.set(w.date, (byDate.get(w.date) ?? 0) + 1));
+    const avgPerDay = byDate.size > 0
+      ? (Array.from(byDate.values()).reduce((a, b) => a + b, 0) / byDate.size).toFixed(1)
+      : '—';
+
+    const withPeak = allW.filter(w => w.peakTs != null);
+    let peakInterval = '—';
+    if (withPeak.length > 0) {
+      const hourBuckets = new Array(24).fill(0) as number[];
+      withPeak.forEach(w => hourBuckets[new Date(w.peakTs!).getHours()]++);
+      const peakHour = hourBuckets.indexOf(Math.max(...hourBuckets));
+      peakInterval = `${String(peakHour).padStart(2,'0')}h–${String(peakHour+1).padStart(2,'0')}h`;
+    }
+
+    const sortedDH = [...dailyHistory].sort((a, b) => a.date.localeCompare(b.date));
+    let streak = 0;
+    for (let i = sortedDH.length - 1; i >= 0; i--) {
+      if (sortedDH[i].maxSession >= 80) streak++;
+      else break;
+    }
+
+    analyticsEl.innerHTML = `
+      <div class="analytics-title">${isPtBR ? 'Resumo' : 'Summary'}</div>
+      <div class="stat-card"><div class="stat-value">${avgPerDay}</div><div class="stat-label">${isPtBR ? 'Janelas/dia' : 'Windows/day'}</div></div>
+      <div class="stat-card"><div class="stat-value">${peakInterval}</div><div class="stat-label">${isPtBR ? 'Pico comum' : 'Common peak'}</div></div>
+      <div class="stat-card"><div class="stat-value">${streak}</div><div class="stat-label">${isPtBR ? 'Dias >80%' : 'Days >80%'}</div></div>
+    `;
+  }
 }
 
 async function openDayDetailModal(date: string): Promise<void> {
@@ -1139,13 +1184,110 @@ function renderDailyChart(dailyData: DailySnapshot[], weeklyResetsAt: string, li
   container.querySelectorAll<HTMLElement>('.daily-col:not(.future)[data-date]').forEach(col => {
     col.addEventListener('click', () => {
       const date = col.dataset.date;
-      if (date) void openDayDetailModal(date);
+      if (date) void openDayCurvePopup(date, col);
     });
   });
 
   fitWindow();
 }
 
+
+async function updateBurnRate(): Promise<void> {
+  const el = document.getElementById('burn-rate-line');
+  if (!el) return;
+  const today = new Date().toLocaleDateString('sv');
+  const points = await window.claudeUsage.getDayTimeSeries(today);
+  if (points.length < 2) { el.textContent = ''; return; }
+  const recent = points.slice(-3);
+  if (recent.length < 2) { el.textContent = ''; return; }
+  const oldest = recent[0];
+  const newest = recent[recent.length - 1];
+  const currentSession = newest.session;
+  if (currentSession < 5) { el.textContent = ''; return; }
+  const deltaPct = newest.session - oldest.session;
+  const deltaHours = (newest.ts - oldest.ts) / 3_600_000;
+  if (deltaHours <= 0) { el.textContent = ''; return; }
+  const burnRate = deltaPct / deltaHours;
+  if (burnRate <= 0) { el.textContent = ''; return; }
+  const remainingPct = 100 - currentSession;
+  const hoursUntilFull = remainingPct / burnRate;
+  if (hoursUntilFull > 6) { el.textContent = ''; return; }
+  const estTime = new Date(newest.ts + hoursUntilFull * 3_600_000);
+  const timeStr = estTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const rateStr = burnRate.toFixed(1);
+  const isPtBR = document.documentElement.lang === 'pt-BR' || navigator.language.startsWith('pt');
+  el.textContent = isPtBR
+    ? `↑ ${rateStr}%/h · esgota ~${timeStr}`
+    : `↑ ${rateStr}%/h · exhausts ~${timeStr}`;
+}
+
+async function openDayCurvePopup(date: string, anchorEl: HTMLElement): Promise<void> {
+  const popup = document.getElementById('day-curve-popup') as HTMLElement;
+  const titleEl = document.getElementById('day-curve-title') as HTMLElement;
+  const emptyEl = document.getElementById('day-curve-empty') as HTMLElement;
+  const closeBtn = document.getElementById('day-curve-close') as HTMLElement;
+
+  if (dayCurveOpenDate === date && !popup.classList.contains('hidden')) {
+    closeDayCurvePopup();
+    return;
+  }
+
+  const rect = anchorEl.getBoundingClientRect();
+  popup.style.left = `${Math.min(rect.left, window.innerWidth - 250)}px`;
+  popup.style.top = `${rect.bottom + 4}px`;
+
+  titleEl.textContent = new Date(date + 'T12:00:00').toLocaleDateString([], { day: '2-digit', month: 'short' });
+  popup.classList.remove('hidden');
+  dayCurveOpenDate = date;
+
+  if (dayCurveChart) { dayCurveChart.destroy(); dayCurveChart = null; }
+
+  const points = await window.claudeUsage.getDayTimeSeries(date);
+
+  if (points.length < 2) {
+    document.querySelector('.day-curve-chart-wrap')!.setAttribute('style', 'display:none');
+    emptyEl.classList.remove('hidden');
+  } else {
+    document.querySelector('.day-curve-chart-wrap')!.setAttribute('style', '');
+    emptyEl.classList.add('hidden');
+    const labels = points.map(p => new Date(p.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
+    const canvas = document.getElementById('day-curve-canvas') as HTMLCanvasElement;
+    dayCurveChart = new Chart(canvas, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          data: points.map(p => Math.min(p.session, 100)),
+          borderColor: '#4CAF50',
+          backgroundColor: 'rgba(76,175,80,0.15)',
+          borderWidth: 1.5,
+          pointRadius: 0,
+          fill: true,
+          tension: 0.3,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false }, tooltip: { enabled: false } },
+        scales: {
+          x: { display: false },
+          y: { display: false, min: 0, max: 100 },
+        },
+        animation: false,
+      },
+    });
+  }
+
+  closeBtn.onclick = closeDayCurvePopup;
+}
+
+function closeDayCurvePopup(): void {
+  const popup = document.getElementById('day-curve-popup');
+  if (popup) popup.classList.add('hidden');
+  if (dayCurveChart) { dayCurveChart.destroy(); dayCurveChart = null; }
+  dayCurveOpenDate = null;
+}
 
 function updateUI(data: UsageData): void {
   const sessionPct = Math.round(data.five_hour.utilization);
@@ -1851,6 +1993,7 @@ function init(): void {
   window.claudeUsage.onUsageUpdated((data) => {
     (document.getElementById('credential-modal') as HTMLElement).classList.add('hidden');
     updateUI(data);
+    void updateBurnRate();
   });
 
   // Atualizar gráfico quando receber dados novos
@@ -1947,7 +2090,10 @@ function init(): void {
 
   // Fecha modais abertos quando a janela é reexibida (popup hide → show não recria o DOM)
   document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible') closeDayDetailModal();
+    if (document.visibilityState === 'visible') {
+      closeDayDetailModal();
+      closeDayCurvePopup();
+    }
   });
 
   window.claudeUsage.onRateLimited((until, resetAt) => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -77,6 +77,7 @@
         </div>
         <span class="gauge-reset" id="reset-session">—</span>
         <span class="gauge-reset-at" id="reset-at-session">—</span>
+        <span class="burn-rate-line" id="burn-rate-line"></span>
       </div>
       <div class="gauge-card">
         <span class="gauge-label" data-i18n="weeklyLabel">Weekly (7d)</span>
@@ -196,6 +197,7 @@
       </div>
       <div id="report-stats" class="report-stats"></div>
       <div id="report-windows" class="report-windows"></div>
+      <div id="report-analytics" class="report-analytics"></div>
     </div>
   </div>
 
@@ -566,6 +568,17 @@
         </div>
       </div>
     </div>
+
+  <div id="day-curve-popup" class="day-curve-popup hidden">
+    <div class="day-curve-header">
+      <span id="day-curve-title" class="day-curve-title"></span>
+      <button id="day-curve-close" class="icon-btn" style="font-size:10px;padding:2px 5px;">✕</button>
+    </div>
+    <div class="day-curve-chart-wrap">
+      <canvas id="day-curve-canvas"></canvas>
+    </div>
+    <div id="day-curve-empty" class="day-curve-empty hidden">Sem dados</div>
+  </div>
 
   <script src="app.js"></script>
 </body>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1665,3 +1665,48 @@ body {
   color: var(--text-secondary);
   min-width: 28px;
 }
+.burn-rate-line {
+  font-size: 9px;
+  color: var(--text-secondary);
+  text-align: center;
+  margin-top: 2px;
+  white-space: nowrap;
+  display: block;
+  min-height: 12px;
+}
+.day-curve-popup {
+  position: absolute;
+  z-index: 300;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  width: 230px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+}
+.day-curve-chart-wrap { height: 80px; position: relative; }
+.day-curve-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
+.day-curve-title { font-size: 10px; color: var(--text-secondary); }
+.day-curve-empty { font-size: 10px; color: var(--text-secondary); text-align: center; padding: 16px 0; }
+.window-peak-time {
+  font-size: 9px;
+  color: var(--text-secondary);
+  margin-left: 4px;
+  opacity: 0.8;
+}
+.report-analytics {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.analytics-title {
+  width: 100%;
+  font-size: 10px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 2px;
+}

--- a/src/services/__tests__/dailySnapshotService.test.ts
+++ b/src/services/__tests__/dailySnapshotService.test.ts
@@ -29,7 +29,8 @@ describe('updateDailySnapshot', () => {
 
     expect(dailyHistory).toHaveLength(1);
     expect(dailyHistory[0]).toMatchObject({ date: TODAY, maxSession: 30, maxWeekly: 50, sessionWindowCount: 1, sessionAccum: 0 });
-    expect(currentWindow).toEqual({ resetsAt: RESET_A, peak: 30, date: TODAY });
+    expect(currentWindow).toMatchObject({ resetsAt: RESET_A, peak: 30, date: TODAY });
+    expect(currentWindow.peakTs).toBeDefined();
     expect(completedWindow).toBeNull();
   });
 
@@ -181,5 +182,51 @@ describe('updateDailySnapshot', () => {
     expect(dailyHistory).toHaveLength(8);
     expect(dailyHistory[dailyHistory.length - 1].date).toBe(TODAY);
     expect(dailyHistory.find(d => d.date === '2026-03-01')).toBeUndefined();
+  });
+
+  // ── peakTs ───────────────────────────────────────────────────────────────────
+
+  it('peakTs: definido na primeira janela (primeiro poll)', () => {
+    const FAKE_NOW = 1_700_000_000_000;
+    const { currentWindow } = updateDailySnapshot([], TODAY, makeUsageData(30, 50, RESET_A), null, FAKE_NOW);
+    expect(currentWindow.peakTs).toBe(FAKE_NOW);
+  });
+
+  it('peakTs: atualizado quando há novo pico', () => {
+    const FAKE_NOW1 = 1_700_000_000_000;
+    const FAKE_NOW2 = 1_700_000_001_000;
+    const { currentWindow: w1 } = updateDailySnapshot([], TODAY, makeUsageData(30, 50, RESET_A), null, FAKE_NOW1);
+    expect(w1.peakTs).toBe(FAKE_NOW1);
+    const history = [{ date: TODAY, maxWeekly: 50, maxSession: 30, sessionWindowCount: 1, sessionAccum: 0 }];
+    const { currentWindow: w2 } = updateDailySnapshot(history, TODAY, makeUsageData(60, 50, RESET_A), w1, FAKE_NOW2);
+    expect(w2.peakTs).toBe(FAKE_NOW2);
+  });
+
+  it('peakTs: NÃO muda quando novo valor é menor que o pico', () => {
+    const FAKE_NOW1 = 1_700_000_000_000;
+    const FAKE_NOW2 = 1_700_000_001_000;
+    const window80 = makeWindow(RESET_A, 80);
+    (window80 as CurrentSessionWindow & { peakTs: number }).peakTs = FAKE_NOW1;
+    const history = [{ date: TODAY, maxWeekly: 50, maxSession: 80, sessionWindowCount: 1, sessionAccum: 0 }];
+    const { currentWindow } = updateDailySnapshot(history, TODAY, makeUsageData(20, 50, RESET_A), window80, FAKE_NOW2);
+    expect(currentWindow.peakTs).toBe(FAKE_NOW1);
+  });
+
+  it('peakTs: propagado para completedWindow ao resetar', () => {
+    const FAKE_NOW = 1_700_000_000_000;
+    const window70 = makeWindow(RESET_A, 70);
+    (window70 as CurrentSessionWindow & { peakTs: number }).peakTs = FAKE_NOW;
+    const history = [{ date: TODAY, maxWeekly: 50, maxSession: 70, sessionWindowCount: 1, sessionAccum: 0 }];
+    const { completedWindow } = updateDailySnapshot(history, TODAY, makeUsageData(14, 52, RESET_B), window70);
+    expect(completedWindow?.peakTs).toBe(FAKE_NOW);
+  });
+
+  it('peakTs: undefined após reset (nova janela sem pico ainda)', () => {
+    const FAKE_NOW = 1_700_000_000_000;
+    const window70 = makeWindow(RESET_A, 70);
+    (window70 as CurrentSessionWindow & { peakTs: number }).peakTs = FAKE_NOW;
+    const history = [{ date: TODAY, maxWeekly: 50, maxSession: 70, sessionWindowCount: 1, sessionAccum: 0 }];
+    const { currentWindow } = updateDailySnapshot(history, TODAY, makeUsageData(14, 52, RESET_B), window70);
+    expect(currentWindow.peakTs).toBeUndefined();
   });
 });

--- a/src/services/dailySnapshotService.ts
+++ b/src/services/dailySnapshotService.ts
@@ -24,6 +24,7 @@ export function updateDailySnapshot(
   today: string,
   data: UsageData,
   currentWindow: CurrentSessionWindow | null,
+  now: number = Date.now(),
 ): UpdateSnapshotResult {
   const weeklyPctInt  = Math.round(data.seven_day.utilization);
   const sessionPctInt = Math.round(data.five_hour.utilization);
@@ -57,11 +58,11 @@ export function updateDailySnapshot(
       if (windowDate && windowDate < today && dailyHistory.length > 0) {
         const prevDay = dailyHistory.find(d => d.date === windowDate)
           ?? dailyHistory[dailyHistory.length - 1];
-        completedWindow = { resetsAt: currentWindow.resetsAt, peak, date: prevDay.date };
+        completedWindow = { resetsAt: currentWindow.resetsAt, peak, date: prevDay.date, peakTs: currentWindow.peakTs };
         prevDay.sessionAccum = (prevDay.sessionAccum ?? 0) + peak;
         // sessionWindowCount não incrementa: a janela já foi contada como o "1" inicial do dia anterior
       } else {
-        completedWindow = { resetsAt: currentWindow.resetsAt, peak, date: today };
+        completedWindow = { resetsAt: currentWindow.resetsAt, peak, date: today, peakTs: currentWindow.peakTs };
         existingDay.sessionAccum  = (existingDay.sessionAccum  ?? 0) + peak;
         existingDay.sessionWindowCount = (existingDay.sessionWindowCount ?? 1) + 1;
       }
@@ -78,7 +79,7 @@ export function updateDailySnapshot(
     if (sessionResetOccurred && currentWindow && dailyHistory.length > 0) {
       const prevDay = dailyHistory[dailyHistory.length - 1];
       const peak = currentWindow.peak;
-      completedWindow = { resetsAt: currentWindow.resetsAt, peak, date: prevDay.date };
+      completedWindow = { resetsAt: currentWindow.resetsAt, peak, date: prevDay.date, peakTs: currentWindow.peakTs };
       prevDay.sessionAccum = (prevDay.sessionAccum ?? 0) + peak;
       // sessionWindowCount não incrementa: a janela já foi contada como o "1" inicial do dia anterior
     }
@@ -101,10 +102,10 @@ export function updateDailySnapshot(
   // Caso contrário (valor já é menor, portanto genuíno da nova sessão), usa sessionPctInt.
   // No próximo poll, Math.max atualiza para o valor real.
   const newCurrentWindow: CurrentSessionWindow = sessionResetOccurred
-    ? { resetsAt: newResetsAt, peak: sessionPctInt >= (completedWindow?.peak ?? 0) ? 0 : sessionPctInt, date: today }
+    ? { resetsAt: newResetsAt, peak: sessionPctInt >= (completedWindow?.peak ?? 0) ? 0 : sessionPctInt, date: today, peakTs: undefined }
     : !currentWindow
-      ? { resetsAt: newResetsAt, peak: sessionPctInt, date: today }           // primeira janela
-      : { resetsAt: currentWindow.resetsAt, peak: Math.max(currentWindow.peak, sessionPctInt), date: currentWindow.date ?? today }; // mesma janela, atualiza pico
+      ? { resetsAt: newResetsAt, peak: sessionPctInt, date: today, peakTs: now }           // primeira janela
+      : { resetsAt: currentWindow.resetsAt, peak: Math.max(currentWindow.peak, sessionPctInt), date: currentWindow.date ?? today, peakTs: sessionPctInt > currentWindow.peak ? now : currentWindow.peakTs }; // mesma janela, atualiza pico
 
   return { dailyHistory, currentWindow: newCurrentWindow, completedWindow };
 }


### PR DESCRIPTION
## Summary

- **Curva de consumo por dia**: popup inline ao clicar em coluna do Ciclo Semanal — Chart.js line com `session%` por hora usando `getDayTimeSeries(date)`; toggle ao clicar novamente
- **Burn rate + previsão**: calcula `%/h` com os últimos 3 polls do dia e exibe abaixo do gauge de sessão (ex: `↑ 4%/h · esgota ~14:30`); suprime se `session < 5%`, menos de 2 pontos, burn rate ≤ 0 ou esgotamento além de 6h
- **Horário do pico**: `peakTs?: number` adicionado em `SessionWindowRecord` e `CurrentSessionWindow`; rastreado no `dailySnapshotService`; exibido nas janelas recentes como `pico às HH:MM`
- **Resumo analítico**: média de janelas/dia, horário mais comum de pico, dias consecutivos com sessão >80% — exibido abaixo da lista de janelas

## Test plan

- [ ] Build limpo (`npm run build`)
- [ ] 194 testes passando (`npm test`)
- [ ] Clicar na barra de um dia com dados no Ciclo Semanal → popup com curva aparece
- [ ] Clicar novamente → popup fecha (toggle)
- [ ] Burn rate aparece no gauge de sessão quando há dados suficientes
- [ ] Janelas recentes com `peakTs` exibem o horário do pico
- [ ] Janelas antigas (sem `peakTs`) não quebram — exibem apenas o %
- [ ] Resumo analítico exibe as 3 métricas corretamente

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)