### PR TITLE
feat: Cost Estimate - Custo estimado por periodo

### DIFF
--- a/BUSINESS_RULES.md
+++ b/BUSINESS_RULES.md
@@ -13,8 +13,9 @@
 5. [Módulo Smart Scheduler (Gestão Preditiva)](#5-módulo-smart-scheduler-gestão-preditiva)
 6. [Módulo de Persistência e Backup](#6-módulo-de-persistência-e-backup)
 7. [Módulo de Sincronização em Nuvem (Cloud Sync)](#7-módulo-de-sincronização-em-nuvem-cloud-sync)
-8. [Módulo de Interface e UX](#8-módulo-de-interface-e-ux)
-9. [Arquitetura Reativa (IPC & Eventos)](#9-arquitetura-reativa-ipc--eventos)
+8. [Módulo de Custo Estimado](#8-módulo-de-custo-estimado)
+9. [Módulo de Interface e UX](#9-módulo-de-interface-e-ux)
+10. [Arquitetura Reativa (IPC & Eventos)](#10-arquitetura-reativa-ipc--eventos)
 
 ---
 
@@ -560,7 +561,69 @@ Se o JWT expirar ou for inválido e o re-exchange com a Anthropic também falhar
 
 ---
 
-## 8. Módulo de Interface e UX
+## 8. Módulo de Custo Estimado
+
+**Arquivo:** `src/services/costService.ts`
+
+### Conceito
+
+O módulo calcula uma **estimativa de custo** baseada na utilização de tokens, convertendo a porcentagem de uso em valores monetários. O objetivo é fornecer ao usuário visibilidade sobre o gasto aproximado com a API da Anthropic.
+
+### Limitações
+
+> **A API `/api/oauth/usage` retorna apenas `utilization` (porcentagem 0-100%), não tokens brutos.** O custo é calculado por **estimativa** usando a seguinte lógica:
+
+```
+1. utilization % → tokens aproximados (baseado no limite do modelo)
+2. tokens → custo usando rates da API pública
+```
+
+**Aviso exibido ao usuário:** `"⚠️ Valor estimado baseado na API padrão. Planos Team/Enterprise podem ter taxas diferentes."`
+
+### Rates da API (USD por milhão de tokens)
+
+| Modelo | Input (/M tokens) | Output (/M tokens) |
+|--------|-------------------|-------------------|
+| Haiku | $0.25 | $1.25 |
+| Sonnet | $3.00 | $15.00 |
+| Opus | $15.00 | $75.00 |
+
+### Cálculo por Período
+
+| Período | Base de Cálculo |
+|---------|-----------------|
+| Session (5h) | `five_hour.utilization` × tokens por 1% × rates |
+| Weekly (7d) | `seven_day.utilization` × tokens por 1% × 7 dias × rates |
+| Monthly | Weekly × 4.3 (estimativa mensal) |
+
+### Settings do Módulo
+
+O módulo utiliza duas configurações em `AppSettings`:
+
+```typescript
+monthlyBudget: number;    // Orçamento mensal (default: $50)
+costModel: 'sonnet' | 'haiku' | 'opus';  // Modelo para cálculo (default: sonnet)
+```
+
+### UI do Modal
+
+O modal de custo exibe 3 abas:
+- **Session**: custo atual da sessão de 5h
+- **Weekly**: custo dos últimos 7 dias
+- **Monthly**: gauge de progresso + orçamento configurável
+
+**Gauge de Orçamento:**
+- Verde: < 50% do orçamento
+- Amarelo: 50-80% do orçamento
+- Vermelho: > 80% do orçamento
+
+### Persistência
+
+Os settings (`monthlyBudget`, `costModel`) são armazenados no `electron-store` via `settingsService.ts`.
+
+---
+
+## 9. Módulo de Interface e UX
 
 **Arquivos:** `src/renderer/app.ts`, `src/renderer/styles.css`
 
@@ -602,7 +665,7 @@ Controlado via `body[data-size]` com CSS vars `--gauge-w`, `--gauge-h`, `--pct-s
 
 ---
 
-## 9. Arquitetura Reativa (IPC & Eventos)
+## 10. Arquitetura Reativa (IPC & Eventos)
 
 ### Fluxo completo de dados
 
@@ -650,4 +713,4 @@ Ao abrir o modal do Smart Plan, o renderer solicita via IPC `get-smart-status` s
 
 ---
 
-*Última atualização: 2026-04-12 — gerado a partir de leitura direta do código-fonte em `src/`.*
+*Última atualização: 2026-04-13 — feat: Cost Estimate (v10.1.0)*

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { pollingService, LastResponseInfo } from './services/pollingService';
 import { getSettings, saveSettings, setActiveAccount, getAccountData, saveAccountData } from './services/settingsService';
+import { calculateCostEstimate } from './services/costService';
 import { syncService } from './services/syncService';
 import { setLaunchAtStartup, isLaunchAtStartupEnabled } from './services/startupService';
 import { checkAndNotify, syncWindowState, sendTestNotification } from './services/notificationService';
@@ -693,6 +694,12 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle('set-poll-interval', (_event, ms: number | null) => {
     pollingService.setCustomInterval(ms);
+  });
+
+  ipcMain.handle('get-cost-estimate', () => {
+    if (!lastUsageData) return null;
+    const account = getAccountData();
+    return calculateCostEstimate(lastUsageData, account.dailyHistory ?? [], account.currentSessionWindow ?? null);
   });
 
   ipcMain.handle('sync:get-status', () => syncService.getStatus());

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -103,6 +103,9 @@ contextBridge.exposeInMainWorld('claudeUsage', {
   getCurrentSessionWindow: (): Promise<import('./models/usageData').CurrentSessionWindow | null> =>
     ipcRenderer.invoke('get-current-session-window'),
 
+  getCostEstimate: (): Promise<import('./services/costService').CostEstimate | null> =>
+    ipcRenderer.invoke('get-cost-estimate'),
+
   chooseAutoBackupFolder: (): Promise<string | null> =>
     ipcRenderer.invoke('choose-auto-backup-folder'),
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -270,6 +270,16 @@ const translations = {
     spLegendNow: 'Now',
     spLegendBreak: 'Break',
     spLegendReset: 'Reset',
+    costModalTitle: 'Estimated Cost',
+    costTabSession: 'Session',
+    costTabWeekly: 'Weekly',
+    costTabMonthly: 'Monthly',
+    costPeriodSession: 'Current session (5h)',
+    costPeriodWeekly: 'Last 7 days',
+    costPeriodMonthly: 'This month',
+    costBudgetOf: 'of',
+    costBudgetLabel: 'Monthly budget:',
+    costWarning: '⚠️ Estimated value based on standard API rates. Team/Enterprise plans may have different rates.',
   },
   'pt-BR': {
     sessionLabel:     'Sessão (5h)',
@@ -419,6 +429,16 @@ const translations = {
     spLegendNow: 'Agora',
     spLegendBreak: 'Intervalo',
     spLegendReset: 'Reset',
+    costModalTitle: 'Custo Estimado',
+    costTabSession: 'Sessão',
+    costTabWeekly: 'Semanal',
+    costTabMonthly: 'Mensal',
+    costPeriodSession: 'Sessão atual (5h)',
+    costPeriodWeekly: 'Últimos 7 dias',
+    costPeriodMonthly: 'Este mês',
+    costBudgetOf: 'de',
+    costBudgetLabel: 'Orçamento mensal:',
+    costWarning: '⚠️ Valor estimado baseado na API padrão. Planos Team/Enterprise podem ter taxas diferentes.',
   },
 } as const;
 
@@ -739,6 +759,7 @@ function barClass(pct: number): string {
 
 let sessionChart: Chart | null = null;
 let weeklyChart:  Chart | null = null;
+let costGaugeChart: Chart | null = null;
 let lastRenderedData: { session: number; weekly: number } | null = null;
 let sessionResetTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -2444,6 +2465,68 @@ function init(): void {
       const status = await window.claudeUsage.sync.getStatus();
       applyCloudSyncStatus(status);
     }
+  });
+
+  // Cost modal
+  function openCostModal(): void {
+    document.getElementById('cost-modal')!.classList.remove('hidden');
+    initCostGauge();
+    loadCostData();
+  }
+
+  function closeCostModal(): void {
+    document.getElementById('cost-modal')!.classList.add('hidden');
+  }
+
+  async function loadCostData(): Promise<void> {
+    const cost = await window.claudeUsage.getCostEstimate();
+    if (!cost) return;
+
+    document.getElementById('cost-session-value')!.textContent = `$${cost.session.total.toFixed(2)}`;
+    document.getElementById('cost-session-input')!.textContent = `$${cost.session.input.toFixed(2)}`;
+    document.getElementById('cost-session-output')!.textContent = `$${cost.session.output.toFixed(2)}`;
+
+    document.getElementById('cost-weekly-value')!.textContent = `$${cost.weekly.total.toFixed(2)}`;
+    document.getElementById('cost-weekly-input')!.textContent = `$${cost.weekly.input.toFixed(2)}`;
+    document.getElementById('cost-weekly-output')!.textContent = `$${cost.weekly.output.toFixed(2)}`;
+
+    document.getElementById('cost-monthly-value')!.textContent = `$${cost.monthly.total.toFixed(2)}`;
+    document.getElementById('cost-monthly-input')!.textContent = `$${cost.monthly.input.toFixed(2)}`;
+    document.getElementById('cost-monthly-output')!.textContent = `$${cost.monthly.output.toFixed(2)}`;
+    document.getElementById('cost-budget-value')!.textContent = `$${cost.budget.toFixed(2)}`;
+    document.getElementById('cost-monthly-pct')!.textContent = String(cost.budgetPercentage);
+    document.getElementById('cost-budget-input')!.value = String(cost.budget);
+
+    if (costGaugeChart) {
+      updateGauge(costGaugeChart, cost.budgetPercentage);
+    }
+  }
+
+  function initCostGauge(): void {
+    if (costGaugeChart) return;
+    costGaugeChart = createGauge('cost-gauge');
+  }
+
+  document.getElementById('btn-cost')!.addEventListener('click', openCostModal);
+  document.getElementById('cost-modal-close')!.addEventListener('click', closeCostModal);
+  document.getElementById('cost-modal')!.addEventListener('click', (e) => {
+    if (e.target === document.getElementById('cost-modal')) closeCostModal();
+  });
+
+  document.querySelectorAll<HTMLElement>('.cost-tab').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tabId = (btn as HTMLElement).dataset.costTab!;
+      document.querySelectorAll('.cost-tab').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.cost-pane').forEach(p => p.classList.add('hidden'));
+      btn.classList.add('active');
+      document.getElementById(`cost-${tabId}`)!.classList.remove('hidden');
+    });
+  });
+
+  document.getElementById('cost-budget-input')!.addEventListener('change', async (e) => {
+    const budget = Math.max(1, Math.min(1000, Number((e.target as HTMLInputElement).value)));
+    await window.claudeUsage.saveSettings({ monthlyBudget: budget });
+    loadCostData();
   });
 }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -26,6 +26,7 @@
         <button id="smart-indicator" class="smart-indicator hidden" data-i18n-title="smartPlan.openDetails">
           <span class="smart-indicator-dot"></span>
         </button>
+      <button class="icon-btn" id="btn-cost" title="Custo estimado">💰</button>
       <button class="icon-btn" id="btn-settings" title="Configurações">⚙</button>
       <button class="icon-btn" id="btn-close" title="Close">✕</button>
     </div>
@@ -565,6 +566,82 @@
             <span class="sp-legend-item"><span class="sp-legend-now-icon"></span><span data-i18n="spLegendNow">Agora</span></span>
             <span class="sp-legend-item"><span class="sp-legend-break-icon"></span><span data-i18n="spLegendBreak">Intervalo</span></span>
             <span class="sp-legend-item"><span id="sp-legend-reset-icon" class="sp-legend-reset-icon">◆</span><span data-i18n="spLegendReset">Reset</span></span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Cost Estimate Modal -->
+    <div id="cost-modal" class="modal-overlay hidden">
+      <div class="modal-box cost-modal-box">
+        <div class="cost-modal-header">
+          <span class="cost-modal-title" data-i18n="costModalTitle">Custo Estimado</span>
+          <button id="cost-modal-close" class="icon-btn" style="font-size:12px;padding:4px 8px;">✕</button>
+        </div>
+        <div class="cost-tabs">
+          <button class="cost-tab active" data-cost-tab="session" data-i18n="costTabSession">Sessão</button>
+          <button class="cost-tab" data-cost-tab="weekly" data-i18n="costTabWeekly">Semanal</button>
+          <button class="cost-tab" data-cost-tab="monthly" data-i18n="costTabMonthly">Mensal</button>
+        </div>
+        <div class="cost-content">
+          <div id="cost-session" class="cost-pane active">
+            <div class="cost-value" id="cost-session-value">$0.00</div>
+            <div class="cost-period" data-i18n="costPeriodSession">Sessão atual (5h)</div>
+            <div class="cost-breakdown">
+              <div class="cost-breakdown-row">
+                <span>Input</span>
+                <span id="cost-session-input">$0.00</span>
+              </div>
+              <div class="cost-breakdown-row">
+                <span>Output</span>
+                <span id="cost-session-output">$0.00</span>
+              </div>
+            </div>
+          </div>
+          <div id="cost-weekly" class="cost-pane">
+            <div class="cost-value" id="cost-weekly-value">$0.00</div>
+            <div class="cost-period" data-i18n="costPeriodWeekly">Últimos 7 dias</div>
+            <div class="cost-breakdown">
+              <div class="cost-breakdown-row">
+                <span>Input</span>
+                <span id="cost-weekly-input">$0.00</span>
+              </div>
+              <div class="cost-breakdown-row">
+                <span>Output</span>
+                <span id="cost-weekly-output">$0.00</span>
+              </div>
+            </div>
+          </div>
+          <div id="cost-monthly" class="cost-pane">
+            <div class="cost-gauge-wrap">
+              <canvas id="cost-gauge"></canvas>
+              <div class="cost-gauge-label"><span id="cost-monthly-pct">0</span>%</div>
+            </div>
+            <div class="cost-value" id="cost-monthly-value">$0.00</div>
+            <div class="cost-budget">
+              <span data-i18n="costBudgetOf">de</span>
+              <span class="cost-budget-value" id="cost-budget-value">$50.00</span>
+            </div>
+            <div class="cost-breakdown">
+              <div class="cost-breakdown-row">
+                <span>Input</span>
+                <span id="cost-monthly-input">$0.00</span>
+              </div>
+              <div class="cost-breakdown-row">
+                <span>Output</span>
+                <span id="cost-monthly-output">$0.00</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="cost-warning" data-i18n="costWarning">
+          ⚠️ Valor estimado baseado na API padrão. Planos Team/Enterprise podem ter taxas diferentes.
+        </div>
+        <div class="cost-settings">
+          <label data-i18n="costBudgetLabel">Orçamento mensal:</label>
+          <div class="cost-budget-input-wrap">
+            <span>$</span>
+            <input type="number" id="cost-budget-input" min="1" max="1000" value="50" />
           </div>
         </div>
       </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1711,3 +1711,163 @@ body {
   letter-spacing: 0.04em;
   margin-bottom: 2px;
 }
+
+/* Cost Modal */
+.cost-modal-box {
+  width: 280px;
+  padding: 16px 20px;
+}
+
+.cost-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.cost-modal-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cost-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 14px;
+}
+
+.cost-tab {
+  flex: 1;
+  padding: 6px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.cost-tab:hover {
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.cost-tab.active {
+  background: var(--accent-blue);
+  border-color: var(--accent-blue);
+  color: #ffffff;
+}
+
+.cost-pane {
+  display: none;
+}
+
+.cost-pane.active {
+  display: block;
+}
+
+.cost-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.cost-period {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.cost-gauge-wrap {
+  position: relative;
+  width: 120px;
+  height: 60px;
+  margin: 0 auto 8px;
+}
+
+.cost-gauge-wrap canvas {
+  width: 120px;
+  height: 60px;
+}
+
+.cost-gauge-label {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.cost-budget {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.cost-budget-value {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cost-breakdown {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.cost-breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.cost-warning {
+  font-size: 10px;
+  color: var(--amber);
+  background: rgba(245, 158, 11, 0.1);
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  margin-top: 12px;
+  line-height: 1.4;
+}
+
+.cost-settings {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.cost-settings label {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.cost-budget-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.cost-budget-input-wrap input {
+  width: 60px;
+  padding: 4px 6px;
+  font-size: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  text-align: right;
+}

--- a/src/services/costService.ts
+++ b/src/services/costService.ts
@@ -1,0 +1,137 @@
+import { getSettings } from './settingsService';
+import { DailySnapshot, CurrentSessionWindow, UsageData } from '../models/usageData';
+
+const DEFAULT_MONTHLY_BUDGET = 50;
+
+const MODEL_RATES = {
+  sonnet: { input: 3.0, output: 15.0 },
+  haiku: { input: 0.25, output: 1.25 },
+  opus: { input: 15.0, output: 75.0 },
+} as const;
+
+type ModelType = keyof typeof MODEL_RATES;
+
+function getTokensPerPercent(model: ModelType): number {
+  switch (model) {
+    case 'haiku':
+      return 4_000_000;
+    case 'opus':
+      return 10_000;
+    case 'sonnet':
+    default:
+      return 1_000_000;
+  }
+}
+
+function calculateCost(
+  inputTokens: number,
+  outputTokens: number,
+  model: ModelType = 'sonnet'
+): number {
+  const rates = MODEL_RATES[model];
+  const inputCost = (inputTokens / 1_000_000) * rates.input;
+  const outputCost = (outputTokens / 1_000_000) * rates.output;
+  return inputCost + outputCost;
+}
+
+export interface CostBreakdown {
+  total: number;
+  input: number;
+  output: number;
+  model: ModelType;
+}
+
+export interface CostEstimate {
+  session: CostBreakdown;
+  weekly: CostBreakdown;
+  monthly: CostBreakdown;
+  budget: number;
+  budgetPercentage: number;
+}
+
+export function percentToTokens(percent: number, model: ModelType = 'sonnet'): number {
+  return Math.round((percent / 100) * getTokensPerPercent(model));
+}
+
+function estimateTokensFromPercent(
+  sessionPercent: number,
+  weeklyPercent: number,
+  model: ModelType = 'sonnet'
+): { sessionInput: number; sessionOutput: number; weeklyInput: number; weeklyOutput: number } {
+  const tokensPerPct = getTokensPerPercent(model);
+
+  const sessionInput = Math.round((sessionPercent / 100) * tokensPerPct * 0.5);
+  const sessionOutput = Math.round((sessionPercent / 100) * tokensPerPct * 0.5);
+
+  const weeklyInput = Math.round((weeklyPercent / 100) * tokensPerPct * 7 * 0.5);
+  const weeklyOutput = Math.round((weeklyPercent / 100) * tokensPerPct * 7 * 0.5);
+
+  return { sessionInput, sessionOutput, weeklyInput, weeklyOutput };
+}
+
+export function calculateCostEstimate(
+  data: UsageData,
+  dailyHistory: DailySnapshot[],
+  currentWindow: CurrentSessionWindow | null
+): CostEstimate {
+  const settings = getSettings();
+  const model = (settings.costModel ?? 'sonnet') as ModelType;
+  const budget = settings.monthlyBudget ?? DEFAULT_MONTHLY_BUDGET;
+
+  const sessionPct = data.five_hour.utilization;
+  const weeklyPct = data.seven_day.utilization;
+
+  const { sessionInput, sessionOutput, weeklyInput, weeklyOutput } = estimateTokensFromPercent(
+    sessionPct,
+    weeklyPct,
+    model
+  );
+
+  const session = {
+    total: calculateCost(sessionInput, sessionOutput, model),
+    input: calculateCost(sessionInput, 0, model),
+    output: calculateCost(0, sessionOutput, model),
+    model,
+  };
+
+  const weekly = {
+    total: calculateCost(weeklyInput, weeklyOutput, model),
+    input: calculateCost(weeklyInput, 0, model),
+    output: calculateCost(0, weeklyOutput, model),
+    model,
+  };
+
+  const monthlyPct = weeklyPct * 4;
+  const { weeklyInput: _mInput, weeklyOutput: _mOutput, sessionInput: _sInput, sessionOutput: _sOutput } = estimateTokensFromPercent(monthlyPct, monthlyPct * 7, model);
+  const monthlyInput = Math.round(_mInput * 4.3);
+  const monthlyOutput = Math.round(_mOutput * 4.3);
+
+  const monthly = {
+    total: calculateCost(monthlyInput, monthlyOutput, model),
+    input: calculateCost(monthlyInput, 0, model),
+    output: calculateCost(0, monthlyOutput, model),
+    model,
+  };
+
+  const budgetPercentage = Math.round((monthly.total / budget) * 100);
+
+  return {
+    session,
+    weekly,
+    monthly,
+    budget,
+    budgetPercentage,
+  };
+}
+
+export function getCostModelLabel(model: ModelType): string {
+  switch (model) {
+    case 'haiku':
+      return 'Haiku';
+    case 'opus':
+      return 'Opus';
+    case 'sonnet':
+    default:
+      return 'Sonnet';
+  }
+}

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -152,6 +152,8 @@ export interface AppSettings {
   cloudSync: CloudSyncSettings;
   showCloudSyncSettings: boolean;
   workSchedule: WorkSchedule;
+  monthlyBudget: number;
+  costModel: 'sonnet' | 'haiku' | 'opus';
 }
 
 const defaults: AppSettings = {
@@ -200,6 +202,8 @@ const defaults: AppSettings = {
     breakStart: '12:00',
     breakEnd: '13:00',
   },
+  monthlyBudget: 50,
+  costModel: 'sonnet',
   cloudSync: {
     enabled: false,
     serverUrl: '',
@@ -258,6 +262,8 @@ const store = new Store<AppSettings>({
     showCloudSyncSettings: { type: 'boolean' },
     cloudSync: { type: 'object' },
     workSchedule: { type: 'object' },
+    monthlyBudget: { type: 'number', minimum: 1, maximum: 1000 },
+    costModel: { type: 'string', enum: ['sonnet', 'haiku', 'opus'] },
   },
 });
 
@@ -294,6 +300,8 @@ export function getSettings(): AppSettings {
     showCloudSyncSettings: store.get('showCloudSyncSettings', defaults.showCloudSyncSettings),
     cloudSync: store.get('cloudSync', defaults.cloudSync) as CloudSyncSettings,
     workSchedule: store.get('workSchedule', defaults.workSchedule) as WorkSchedule,
+    monthlyBudget: store.get('monthlyBudget', defaults.monthlyBudget),
+    costModel: store.get('costModel', defaults.costModel),
   };
 }
 


### PR DESCRIPTION
## Resumo

Implementa funcionalidade de **custo estimado** baseado no uso de tokens, exibindo o consumo em diferentes períodos.

## O que foi implementado

### Novo serviço: `costService.ts`
- Cálculo de custo usando rates da API Anthropic (estimativa)
- Suporte a 3 modelos: Sonnet, Haiku, Opus
- Períodos: Session (5h), Weekly (7d), Monthly

### Modal de Custo
- 3 abas: Session | Weekly | Monthly
- Gauge de orçamento mensal com cores (verde < 50%, amarelo 50-80%, vermelho > 80%)
- Campo configurável para orçamento mensal (default $50)
- Breakdown input/output por período

### UI
- Novo botão 💰 no header (ao lado de ⚙)
- Modal com design consistente aos existentes
- Traduções EN e PT-BR

### Settings
- `monthlyBudget` - orçamento mensal (default: $50)
- `costModel` - modelo para cálculo (default: sonnet)

## Observação

A API `/api/oauth/usage` retorna apenas **utilization (%)**, não tokens brutos. O custo é uma **estimativa** baseada na conversão de % para tokens aproximados. Um aviso é exibido indicando que planos Team/Enterprise podem ter taxas diferentes.

## Fecha

Closes #92
