### PR TITLE
fix: final=0 e maxSession=0 incorretos ao fechar janela de sessão

### DIFF
--- a/claude-code-planos/fix-session-window-final-and-maxsession.md
+++ b/claude-code-planos/fix-session-window-final-and-maxsession.md
@@ -1,0 +1,59 @@
+# Fix: dados errados no registro de fechamento de janela de sessão
+
+## Contexto
+
+Ao fechar uma janela de sessão de 5h, o registro gerado em `sessionWindows` contém:
+- `final: 0` — deveria ser o último valor não-zero antes do reset (ex: 94%)
+- `maxSession` sobrescrito com 0 no DailySnapshot — deveria preservar o pico histórico do dia
+
+**Exportação de backup confirma os dados errados:**
+```json
+// sessionWindows
+{ "resetsAt": "2026-04-19T01:00:00...", "peak": 100, "final": 0, "date": "2026-04-18" }
+// usageHistory mostra: session: 94 → session: 0 (reset)
+```
+
+## Causa Raiz
+
+**Bug 1 — `final: 0` (race condition da API)**
+
+A API pode retornar `utilization=0` com o `resets_at` antigo antes de refletir o reset
+oficialmente. Nesse poll intermediário, o código atualiza:
+```typescript
+// dailySnapshotService.ts linha 102
+final: sessionPctInt  // → 0 (sem reset detectado ainda)
+```
+No poll seguinte, o reset é detectado, mas `currentWindow.final` já está em 0
+→ `completedWindow.final = 0` (deveria ser 94%).
+
+**Bug 2 — `maxSession` sobrescrito com 0 na detecção de reset**
+
+```typescript
+// dailySnapshotService.ts linha 67
+existingDay.maxSession = sessionPctInt;  // sessionPctInt = 0 (nova janela recém-iniciada)
+```
+Destroi o pico histórico do dia. O branch sem reset já usa `Math.max` corretamente.
+
+## Correções
+
+### Fix 1 — linha 102
+```typescript
+// ANTES:
+final: sessionPctInt,
+// DEPOIS:
+final: sessionPctInt > 0 ? sessionPctInt : currentWindow.final,
+```
+
+### Fix 2 — linha 67
+```typescript
+// ANTES:
+existingDay.maxSession = sessionPctInt;
+// DEPOIS:
+existingDay.maxSession = Math.max(existingDay.maxSession ?? 0, peak);
+```
+
+## Arquivo
+`src/services/dailySnapshotService.ts`
+
+## Status
+✅ Concluído

--- a/src/services/__tests__/dailySnapshotService.test.ts
+++ b/src/services/__tests__/dailySnapshotService.test.ts
@@ -98,7 +98,7 @@ describe('updateDailySnapshot', () => {
 
     expect(dailyHistory[0].sessionAccum).toBe(70);  // usa peak, não último valor polled
     expect(dailyHistory[0].sessionWindowCount).toBe(2);
-    expect(dailyHistory[0].maxSession).toBe(14);    // reinicia com valor da nova janela
+    expect(dailyHistory[0].maxSession).toBe(70);    // Math.max(maxSession anterior=70, peak=70) — preserva máximo do dia
     expect(currentWindow).toEqual({ resetsAt: RESET_B, peak: 0, final: 0, date: TODAY, peakTs: undefined });
     expect(completedWindow).toMatchObject({ resetsAt: RESET_A, peak: 70, final: 70, date: TODAY });
   });
@@ -156,18 +156,18 @@ describe('updateDailySnapshot', () => {
     const r1 = updateDailySnapshot(history, TODAY, makeUsageData(14, 52, RESET_B), makeWindow(RESET_A, 70));
     expect(r1.dailyHistory[0].sessionAccum).toBe(70);
     expect(r1.dailyHistory[0].sessionWindowCount).toBe(2);
-    expect(r1.dailyHistory[0].maxSession).toBe(14);
+    expect(r1.dailyHistory[0].maxSession).toBe(70); // Math.max(70 anterior, peak=70) — preserva máximo
 
-    // Janela 2 cresce até 50
+    // Janela 2 cresce até 50 — maxSession já é 70, não desce
     const r2 = updateDailySnapshot(r1.dailyHistory, TODAY, makeUsageData(50, 53, RESET_B), makeWindow(RESET_B, 50));
-    expect(r2.dailyHistory[0].maxSession).toBe(50);
+    expect(r2.dailyHistory[0].maxSession).toBe(70); // Math.max(70, 50) = 70 mantém o pico do dia
     expect(r2.currentWindow.peak).toBe(50);
 
     // Segundo reset — pico da janela 2 = 50
     const r3 = updateDailySnapshot(r2.dailyHistory, TODAY, makeUsageData(5, 54, RESET_C), makeWindow(RESET_B, 50));
     expect(r3.dailyHistory[0].sessionAccum).toBe(120); // 70 + 50
     expect(r3.dailyHistory[0].sessionWindowCount).toBe(3);
-    expect(r3.dailyHistory[0].maxSession).toBe(5);
+    expect(r3.dailyHistory[0].maxSession).toBe(70); // Math.max(70, peak=50) = 70 — pico do dia preservado
     expect(r3.completedWindow).toMatchObject({ resetsAt: RESET_B, peak: 50 });
   });
 

--- a/src/services/dailySnapshotService.ts
+++ b/src/services/dailySnapshotService.ts
@@ -64,7 +64,7 @@ export function updateDailySnapshot(
         existingDay.sessionAccum  = (existingDay.sessionAccum  ?? 0) + peak;
         existingDay.sessionWindowCount = (existingDay.sessionWindowCount ?? 1) + 1;
       }
-      existingDay.maxSession    = sessionPctInt;
+      existingDay.maxSession    = Math.max(existingDay.maxSession ?? 0, peak);
     } else {
       existingDay.maxSession = Math.max(existingDay.maxSession ?? 0, sessionPctInt);
     }
@@ -99,7 +99,7 @@ export function updateDailySnapshot(
     ? { resetsAt: newResetsAt, peak: 0, final: 0, date: today, peakTs: undefined }
     : !currentWindow
       ? { resetsAt: newResetsAt, peak: sessionPctInt, final: sessionPctInt, date: today, peakTs: now }
-      : { resetsAt: currentWindow.resetsAt, peak: Math.max(currentWindow.peak, sessionPctInt), final: sessionPctInt, date: currentWindow.date ?? today, peakTs: sessionPctInt > currentWindow.peak ? now : currentWindow.peakTs };
+      : { resetsAt: currentWindow.resetsAt, peak: Math.max(currentWindow.peak, sessionPctInt), final: sessionPctInt > 0 ? sessionPctInt : currentWindow.final, date: currentWindow.date ?? today, peakTs: sessionPctInt > currentWindow.peak ? now : currentWindow.peakTs };
 
   return { dailyHistory, currentWindow: newCurrentWindow, completedWindow };
 }


### PR DESCRIPTION
## Summary
- `final: 0` no registro de janela fechada causado por race condition: a API pode retornar `utilization=0` com o `resets_at` antigo antes de refletir o reset. Fix: só atualizar `final` quando `sessionPctInt > 0`
- `maxSession` sobrescrito com `sessionPctInt=0` (nova janela) ao detectar reset, apagando o pico histórico do dia. Fix: `Math.max(existingMaxSession, peak)` onde `peak` é o pico da janela recém-fechada

## Root Cause
`dailySnapshotService.ts` linhas 67 e 102 — ambos no branch `if (sessionResetOccurred)`.

## Related
Closes #111

## Test plan
- [x] \`npm run build\` exits cleanly
- [x] \`npm test\` — 387/387 testes passando
- [ ] Verificar no próximo reset de janela: \`final\` mostra valor não-zero, \`Pico de sessão\` preserva o pico correto

🤖 Generated with [Claude Code](https://claude.com/claude-code)