### PR TITLE
fix: aumentar tamanho dos ícones do header para 32px

### DIFF
--- a/minimax-planos/fix-header-icons-size.md
+++ b/minimax-planos/fix-header-icons-size.md
@@ -1,0 +1,41 @@
+# Fix: Aumentar tamanho dos ícones do header
+
+**Status:** Aguardando confirmação para PR
+**Branch:** `fix/header-icons-size`
+
+---
+
+## Objetivo
+
+Aumentar tamanho dos botões/ícones do header para melhor visibilidade e área clicável.
+
+---
+
+## Mudanças — `src/renderer/styles.css`
+
+| Seletor | Propriedade | Atual | Novo |
+|---------|-------------|-------|------|
+| `.icon-btn` | width, height | 24px | 32px |
+| `.icon-btn` | font-size | 12px | 16px |
+| `.smart-indicator` | width, height | 24px | 32px |
+| `.smart-indicator-dot` | width, height | 12px | 16px |
+| `#btn-online-users` | font-size | 11px | 13px |
+
+---
+
+## Verificação
+
+1. `npm run build` — build limpo
+2. `npm test` — 387 testes
+3. Verificar visualmente os ícones do header
+
+---
+
+## Progresso
+
+- [x] Plano criado
+- [x] Branch criada
+- [x] Implementar CSS
+- [x] Build + testes
+- [x] Commit + push
+- [ ] PR (aguardando confirmação)

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -183,8 +183,8 @@ body {
 }
 
 .icon-btn {
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   border-radius: 5px;
   border: none;
   background: transparent;
@@ -193,7 +193,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 16px;
   transition: all 0.2s var(--ease-out);
 }
 
@@ -277,7 +277,7 @@ body {
   align-items: center;
   gap: 4px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: 13px;
 }
 #online-users-count {
   font-weight: 500;
@@ -1628,8 +1628,8 @@ body {
   background: transparent;
   border: none;
   border-radius: 5px;
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   padding: 0;
   cursor: pointer;
   display: flex;
@@ -1641,8 +1641,8 @@ body {
   background: var(--surface);
 }
 .smart-indicator-dot {
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background: var(--text-secondary);
   transition: background 0.3s;


### PR DESCRIPTION
## Summary\n- icon-btn: 24px para 32px, font 12px para 16px\n- smart-indicator: 24px para 32px\n- smart-indicator-dot: 12px para 16px\n- btn-online-users: 11px para 13px\n\n## Testes\n- npm run build ✅\n- npm test 387 ✅