### PR TITLE
fix: barra de conta respeita showAccountBar ao aplicar profile

### DIFF
--- a/src/presentation/components/settings/SettingsModal.ts
+++ b/src/presentation/components/settings/SettingsModal.ts
@@ -26,8 +26,10 @@ export function setupSettingsModal(
   onSave: () => void,
   loadCloudSync: () => void,
 ): void {
-  document.getElementById('btn-settings')?.addEventListener('click', () => {
+  document.getElementById('btn-settings')?.addEventListener('click', async () => {
     document.getElementById('settings-modal')?.classList.remove('hidden');
+    const settings = await window.claudeUsage.getSettings();
+    loadSettingsToModal(settings);
     loadCloudSync();
   });
   document.getElementById('btn-settings-close')?.addEventListener('click', () => {

--- a/src/presentation/components/status/AccountBar.ts
+++ b/src/presentation/components/status/AccountBar.ts
@@ -1,4 +1,5 @@
 import { fitWindow } from '../../layouts/PopupLayout';
+import { appStore } from '../../../renderer/stores/appStore';
 
 type Profile = { account: { display_name: string; email: string; has_claude_pro: boolean; has_claude_max: boolean } };
 
@@ -27,7 +28,7 @@ export function applyProfile(profile: Profile): void {
   }
   if (barEl) {
     barEl.dataset.hasProfile = 'true';
-    barEl.style.display = '';
+    barEl.style.display = appStore.get('showAccountBar') ? '' : 'none';
     fitWindow();
   }
 }

--- a/src/presentation/hooks/useProfile.ts
+++ b/src/presentation/hooks/useProfile.ts
@@ -1,12 +1,9 @@
-import { appStore } from '../stores/appStore';
-
 let registered = false;
 
 export function useProfile(): void {
   if (registered) return;
   registered = true;
 
-  window.claudeUsage.onProfileUpdated((profile) => {
-    appStore.set('showAccountBar', true);
+  window.claudeUsage.onProfileUpdated(() => {
   });
 }

--- a/src/renderer/AppBootstrap.ts
+++ b/src/renderer/AppBootstrap.ts
@@ -18,6 +18,7 @@ import { setupCloudSync, loadCloudSyncStatus } from '../presentation/components/
 import { setupServerStatus } from '../presentation/components/status/ServerStatus';
 import { applyProfile } from '../presentation/components/status/AccountBar';
 import { applyAutoRefresh, startNextPollCountdown, stopNextPollCountdown, isAutoRefreshEnabled } from '../presentation/shared/autoRefresh';
+import { appStore } from './stores/appStore';
 import { setupHistoryHandlers, setupReportHandlers } from '../presentation/components/history/HistoryPanel';
 import { setupCliSessionsHandlers } from '../presentation/components/modals/CliSessionsModal';
 import { setupHeaderHandlers } from '../presentation/components/header/HeaderHandlers';
@@ -142,6 +143,7 @@ async function loadSettings(): Promise<void> {
     setLang(settings.language as Lang);
     applyTranslations();
     loadSettingsToModal(settings);
+    appStore.set('showAccountBar', settings.showAccountBar);
     await loadCloudSyncStatus();
   } catch (err) {
     console.error('[App] loadSettings failed:', err);
@@ -156,6 +158,9 @@ async function saveSettingsFromUI(): Promise<void> {
     applySize(settings.windowSize!);
     applySectionVisibility(settings as { showDailyChart: boolean; showExtraBars: boolean; showFooter: boolean; showAccountBar: boolean });
     applyAutoRefresh(settings.autoRefresh!, settings.autoRefreshInterval!);
+    if (settings.showAccountBar !== undefined) {
+      appStore.set('showAccountBar', settings.showAccountBar);
+    }
     if (settings.language) {
       setLang(settings.language as Lang);
       applyTranslations();

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -24,6 +24,6 @@ export const appStore = createStore<AppState>({
   autoRefreshEnabled: false,
   autoRefreshIntervalMs: 300 * 1000,
   isRateLimited: false,
-  showAccountBar: true,
+  showAccountBar: false,
   extraSectionAllowed: true,
 });

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -146,6 +146,7 @@ export interface AppSettings {
   showGeneralSettings: boolean;
   showNotifSettings:   boolean;
   showBackupSettings:  boolean;
+  showAccountBar: boolean;
   compactMode: boolean;
   essentialMode: boolean;
   settingsUpdatedAt: number;
@@ -190,6 +191,7 @@ const defaults: AppSettings = {
   showGeneralSettings: true,
   showNotifSettings:   true,
   showBackupSettings:  true,
+  showAccountBar: false,
   compactMode: false,
   essentialMode: false,
   settingsUpdatedAt: 0,
@@ -256,6 +258,7 @@ const store = new Store<AppSettings>({
     showGeneralSettings: { type: 'boolean' },
     showNotifSettings:   { type: 'boolean' },
     showBackupSettings:  { type: 'boolean' },
+    showAccountBar: { type: 'boolean' },
     compactMode: { type: 'boolean' },
     essentialMode: { type: 'boolean' },
     settingsUpdatedAt: { type: 'number' },
@@ -294,6 +297,7 @@ export function getSettings(): AppSettings {
     showGeneralSettings: store.get('showGeneralSettings', defaults.showGeneralSettings),
     showNotifSettings:   store.get('showNotifSettings',   defaults.showNotifSettings),
     showBackupSettings:  store.get('showBackupSettings',  defaults.showBackupSettings),
+    showAccountBar: store.get('showAccountBar', defaults.showAccountBar),
     compactMode: store.get('compactMode', defaults.compactMode),
     essentialMode: store.get('essentialMode', defaults.essentialMode),
     settingsUpdatedAt: store.get('settingsUpdatedAt', 0) as number,
@@ -370,6 +374,7 @@ export function saveSettings(settings: Partial<AppSettings>): void {
   if (settings.showGeneralSettings !== undefined) store.set('showGeneralSettings', settings.showGeneralSettings);
   if (settings.showNotifSettings   !== undefined) store.set('showNotifSettings',   settings.showNotifSettings);
   if (settings.showBackupSettings  !== undefined) store.set('showBackupSettings',  settings.showBackupSettings);
+  if (settings.showAccountBar !== undefined) store.set('showAccountBar', settings.showAccountBar);
   if (settings.compactMode !== undefined) store.set('compactMode', settings.compactMode);
   if (settings.essentialMode !== undefined) store.set('essentialMode', settings.essentialMode);
   if (settings.settingsUpdatedAt !== undefined) store.set('settingsUpdatedAt', settings.settingsUpdatedAt);


### PR DESCRIPTION
## Problema\nA opcao de mostrar/esconder a barra de conta nao funcionava porque applyProfile definia display = '' incondicionalmente, sobrescrevendo applySectionVisibility.\n\n## Solucao\nVerificar appStore.get('showAccountBar') antes de definir display na barra.\n\n## Testing\n- 451 testes passando\n- Build limpo