### PR TITLE
fix: grafico semanal toggle agora esconde secao completa

### DIFF
--- a/src/presentation/layouts/PopupLayout.ts
+++ b/src/presentation/layouts/PopupLayout.ts
@@ -25,7 +25,7 @@ export function applyTheme(theme: string): void {
 }
 
 export function applySectionVisibility(opts: { showDailyChart: boolean; showExtraBars: boolean; showFooter: boolean; showAccountBar: boolean }): void {
-  const dailyChart = document.getElementById('history-section');
+  const dailyChart = document.getElementById('daily-chart-section');
   const extraSection = document.getElementById('extra-section');
   const footer = document.querySelector('.footer') as HTMLElement;
   const accountBar = document.getElementById('account-bar');

--- a/src/presentation/layouts/PopupLayout.ts
+++ b/src/presentation/layouts/PopupLayout.ts
@@ -25,7 +25,7 @@ export function applyTheme(theme: string): void {
 }
 
 export function applySectionVisibility(opts: { showDailyChart: boolean; showExtraBars: boolean; showFooter: boolean; showAccountBar: boolean }): void {
-  const dailyChart = document.getElementById('daily-chart-section');
+  const dailyChart = document.getElementById('history-section');
   const extraSection = document.getElementById('extra-section');
   const footer = document.querySelector('.footer') as HTMLElement;
   const accountBar = document.getElementById('account-bar');

--- a/src/renderer/partials/shell/history-section.html
+++ b/src/renderer/partials/shell/history-section.html
@@ -1,13 +1,15 @@
-<div class="history-header">
-      <span class="history-label" data-i18n="dailyHistoryLabel">Ciclo semanal</span>
-      <div class="history-header-actions">
-        <button class="history-btn" id="btn-clear-history" data-i18n="clearHistoryBtn">Limpar</button>
-        <button class="history-btn" id="btn-backup-history" data-i18n="backupHistoryBtn">Backup</button>
-        <button class="history-btn" id="btn-import-history" data-i18n="importHistoryBtn">Import</button>
-        <button class="history-icon-btn" id="btn-edit-history" data-i18n="editHistoryBtn" title="Editar">✎</button>
+<div id="daily-chart-section">
+  <div class="history-header">
+        <span class="history-label" data-i18n="dailyHistoryLabel">Ciclo semanal</span>
+        <div class="history-header-actions">
+          <button class="history-btn" id="btn-clear-history" data-i18n="clearHistoryBtn">Limpar</button>
+          <button class="history-btn" id="btn-backup-history" data-i18n="backupHistoryBtn">Backup</button>
+          <button class="history-btn" id="btn-import-history" data-i18n="importHistoryBtn">Import</button>
+          <button class="history-icon-btn" id="btn-edit-history" data-i18n="editHistoryBtn" title="Editar">✎</button>
+        </div>
       </div>
-    </div>
-    <div id="history-section">
-      <div id="daily-chart" class="daily-chart"></div>
-      <div id="daily-legend" class="daily-legend"></div>
-    </div>
+      <div id="history-section">
+        <div id="daily-chart" class="daily-chart"></div>
+        <div id="daily-legend" class="daily-legend"></div>
+      </div>
+</div>


### PR DESCRIPTION
## Problema
O toggle de Grafico Semanal (showDailyChart) so escondia o grafico interno mas o header com botoes (Limpar, Backup, Import, Editar) continuava visivel.

## Solucao
Envolver o header e o grafico em um container #daily-chart-section para que quando o toggle e desmarcado, toda a secao desapareca.

## Arquivos modificados
- history-section.html - adicionou wrapper #daily-chart-section
- PopupLayout.ts - usa #daily-chart-section como seletor