### PR TITLE
fix: esconder extra-section quando API nao retorna dados de creditos

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ let cachedProfile: ProfileData | null = null;
 let cachedProfileAt = 0;
 
 const POPUP_WIDTH  = 460;
-const POPUP_HEIGHT = 250;
+const POPUP_HEIGHT = 300;
 
 function markAsProgrammaticMove(): void {
   isProgrammaticMove = true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ let cachedProfile: ProfileData | null = null;
 let cachedProfileAt = 0;
 
 const POPUP_WIDTH  = 460;
-const POPUP_HEIGHT = 210;
+const POPUP_HEIGHT = 250;
 
 function markAsProgrammaticMove(): void {
   isProgrammaticMove = true;

--- a/src/presentation/layouts/PopupLayout.ts
+++ b/src/presentation/layouts/PopupLayout.ts
@@ -9,7 +9,8 @@ export function fitWindow(): void {
     const footer = document.querySelector('.footer') as HTMLElement;
     const accountBarH = (accountBar?.style.display !== 'none' ? accountBar?.offsetHeight : 0) ?? 0;
     const h = header.offsetHeight + accountBarH + (smartRecBar?.offsetHeight ?? 0) + content.scrollHeight + (footer?.offsetHeight ?? 0);
-    window.claudeUsage.setWindowHeight(h);
+    const minHeight = 300;
+    window.claudeUsage.setWindowHeight(Math.max(h, minHeight));
   });
 }
 

--- a/src/presentation/layouts/PopupLayout.ts
+++ b/src/presentation/layouts/PopupLayout.ts
@@ -9,8 +9,7 @@ export function fitWindow(): void {
     const footer = document.querySelector('.footer') as HTMLElement;
     const accountBarH = (accountBar?.style.display !== 'none' ? accountBar?.offsetHeight : 0) ?? 0;
     const h = header.offsetHeight + accountBarH + (smartRecBar?.offsetHeight ?? 0) + content.scrollHeight + (footer?.offsetHeight ?? 0);
-    const minHeight = 300;
-    window.claudeUsage.setWindowHeight(Math.max(h, minHeight));
+    window.claudeUsage.setWindowHeight(h);
   });
 }
 

--- a/src/presentation/pages/Dashboard.ts
+++ b/src/presentation/pages/Dashboard.ts
@@ -2,6 +2,7 @@ import { sessionGauge, weeklyGauge, trayIcon } from '../../renderer/chartsInstan
 import { formatResetsIn, formatResetAt } from '../shared/formatters';
 import { tr, getLang } from '../layouts/i18n';
 import { fitWindow } from '../layouts/PopupLayout';
+import { appStore } from '../../renderer/stores/appStore';
 
 type UsageWindow = { utilization: number; resets_at: string };
 type ExtraUsage = { is_enabled: boolean; monthly_limit: number; used_credits: number };
@@ -61,6 +62,14 @@ export function updateDashboard(data: UsageData, onResetsAtChange: (v: string) =
     } else {
       creditsRow.style.display = 'none';
     }
+  }
+
+  const extraSection = document.getElementById('extra-section');
+  const sonnetVisible = sonnetRow?.style.display !== 'none';
+  const creditsVisible = creditsRow?.style.display !== 'none';
+  const showExtras = appStore.get('extraSectionAllowed') !== false;
+  if (extraSection) {
+    extraSection.style.display = (sonnetVisible || creditsVisible) && showExtras ? '' : 'none';
   }
 
   const updatedEl = document.getElementById('updated-text');

--- a/src/renderer/AppBootstrap.ts
+++ b/src/renderer/AppBootstrap.ts
@@ -144,6 +144,7 @@ async function loadSettings(): Promise<void> {
     applyTranslations();
     loadSettingsToModal(settings);
     appStore.set('showAccountBar', settings.showAccountBar);
+    appStore.set('extraSectionAllowed', settings.showExtraBars);
     await loadCloudSyncStatus();
   } catch (err) {
     console.error('[App] loadSettings failed:', err);
@@ -160,6 +161,9 @@ async function saveSettingsFromUI(): Promise<void> {
     applyAutoRefresh(settings.autoRefresh!, settings.autoRefreshInterval!);
     if (settings.showAccountBar !== undefined) {
       appStore.set('showAccountBar', settings.showAccountBar);
+    }
+    if (settings.showExtraBars !== undefined) {
+      appStore.set('extraSectionAllowed', settings.showExtraBars);
     }
     if (settings.language) {
       setLang(settings.language as Lang);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1753,7 +1753,7 @@ body {
 /* ── Settings Modal ─────────────────────────────────────────────────── */
 .settings-modal-box {
   width: 400px;
-  max-height: 80vh;
+  max-height: 90vh;
   overflow: hidden;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problema
O container #extra-section (barra cinza) aparecia mesmo quando a API da Anthropic nao retornava dados de creditos (extra_usage), resultando em uma barra cinza vazia.

## Solucao
1. Dashboard.ts agora verifica se alguma row (sonnet ou credits) esta visivel apos processar os dados da API
2. Se nenhuma row esta visivel, o container e escondido
3. AppBootstrap.ts agora sincroniza extraSectionAllowed no appStore com showExtraBars dos settings

## Comportamento
- Se toggle Barras de creditos/Sonnet estiver OFF → container nunca aparece
- Se toggle estiver ON mas API nao retorna dados → container fica escondido
- Se toggle estiver ON e API retorna dados → container aparece normalmente