### PR TITLE
fix: barra cinza extra-section agora aparece apenas quando API retorna dados

### DIFF
--- a/src/presentation/layouts/PopupLayout.ts
+++ b/src/presentation/layouts/PopupLayout.ts
@@ -26,12 +26,10 @@ export function applyTheme(theme: string): void {
 
 export function applySectionVisibility(opts: { showDailyChart: boolean; showExtraBars: boolean; showFooter: boolean; showAccountBar: boolean }): void {
   const dailyChart = document.getElementById('daily-chart-section');
-  const extraSection = document.getElementById('extra-section');
   const footer = document.querySelector('.footer') as HTMLElement;
   const accountBar = document.getElementById('account-bar');
 
   if (dailyChart) dailyChart.style.display = opts.showDailyChart ? '' : 'none';
-  if (extraSection) extraSection.style.display = opts.showExtraBars ? '' : 'none';
   if (footer) footer.style.display = opts.showFooter ? '' : 'none';
   if (accountBar) accountBar.style.display = opts.showAccountBar ? '' : 'none';
 

--- a/src/presentation/pages/Dashboard.ts
+++ b/src/presentation/pages/Dashboard.ts
@@ -2,7 +2,6 @@ import { sessionGauge, weeklyGauge, trayIcon } from '../../renderer/chartsInstan
 import { formatResetsIn, formatResetAt } from '../shared/formatters';
 import { tr, getLang } from '../layouts/i18n';
 import { fitWindow } from '../layouts/PopupLayout';
-import { appStore } from '../../renderer/stores/appStore';
 
 type UsageWindow = { utilization: number; resets_at: string };
 type ExtraUsage = { is_enabled: boolean; monthly_limit: number; used_credits: number };
@@ -67,9 +66,8 @@ export function updateDashboard(data: UsageData, onResetsAtChange: (v: string) =
   const extraSection = document.getElementById('extra-section');
   const sonnetVisible = sonnetRow?.style.display !== 'none';
   const creditsVisible = creditsRow?.style.display !== 'none';
-  const showExtras = appStore.get('extraSectionAllowed') !== false;
   if (extraSection) {
-    extraSection.style.display = (sonnetVisible || creditsVisible) && showExtras ? '' : 'none';
+    extraSection.style.display = (sonnetVisible || creditsVisible) ? '' : 'none';
   }
 
   const updatedEl = document.getElementById('updated-text');

--- a/src/renderer/AppBootstrap.ts
+++ b/src/renderer/AppBootstrap.ts
@@ -144,7 +144,6 @@ async function loadSettings(): Promise<void> {
     applyTranslations();
     loadSettingsToModal(settings);
     appStore.set('showAccountBar', settings.showAccountBar);
-    appStore.set('extraSectionAllowed', settings.showExtraBars);
     await loadCloudSyncStatus();
   } catch (err) {
     console.error('[App] loadSettings failed:', err);
@@ -161,9 +160,6 @@ async function saveSettingsFromUI(): Promise<void> {
     applyAutoRefresh(settings.autoRefresh!, settings.autoRefreshInterval!);
     if (settings.showAccountBar !== undefined) {
       appStore.set('showAccountBar', settings.showAccountBar);
-    }
-    if (settings.showExtraBars !== undefined) {
-      appStore.set('extraSectionAllowed', settings.showExtraBars);
     }
     if (settings.language) {
       setLang(settings.language as Lang);


### PR DESCRIPTION
## Problema
A barra cinza (extra-section) aparecia quando o toggle showExtraBars estava ON, mesmo quando a API da Anthropic nao retornava dados de creditos.

## Solucao
- Removido extra-section de applySectionVisibility
- Dashboard.ts agora controla a visibilidade baseado APENAS nos dados da API
- Toggle showExtraBars (Barras de creditos/Sonnet) agora nao afeta a barra cinza

## Comportamento
- Barra cinza aparece apenas quando API retorna dados de credits (extra_usage)
- Toggle agora pode ser usado para outras finalidades futuras